### PR TITLE
Improve input panel spacing and responsiveness

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -61,6 +61,7 @@ h3 {
   max-width: 1280px;
   margin: 0 auto;
   padding: 16px 18px 24px;
+  min-height: 100vh;
 }
 
 .grid {
@@ -69,7 +70,58 @@ h3 {
 }
 
 .grid.cols-2 {
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: minmax(320px, 360px) 1fr;
+  align-items: stretch;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap, 12px);
+}
+
+.stack-sm {
+  --stack-gap: 8px;
+}
+
+.stack .toolbar {
+  margin: 0;
+}
+
+#inputs {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 40px);
+  min-height: 0;
+}
+
+.inputs-scroll {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.inputs-toolbar {
+  position: sticky;
+  top: 0;
+  padding: 6px 0 10px;
+  background: var(--panel);
+  z-index: 1;
+  box-shadow: 0 6px 12px rgba(15, 17, 21, 0.65);
+  margin: 0;
+}
+
+.inputs-toolbar::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 1px;
+  background: #222632;
+  opacity: 0.6;
 }
 
 .panel {
@@ -82,14 +134,38 @@ h3 {
 
 .row {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
 }
 
 .row4 {
   display: grid;
-  grid-template-columns: repeat(4, minmax(120px, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+@media (max-width: 900px) {
+  .grid.cols-2 {
+    grid-template-columns: 1fr;
+  }
+
+  #inputs {
+    max-height: none;
+  }
+
+  .inputs-scroll {
+    overflow: visible;
+    padding-right: 0;
+  }
+
+  .inputs-toolbar {
+    position: static;
+    box-shadow: none;
+  }
+
+  .inputs-toolbar::after {
+    display: none;
+  }
 }
 
 .rowAuto {

--- a/public/index.html
+++ b/public/index.html
@@ -13,73 +13,77 @@
         <!-- LEFT: Inputs -->
         <aside class="panel" id="inputs">
           <h1>Layout Inputs</h1>
-          <div class="toolbar no-print">
-            <button class="btn" id="preset-letter">Letter 8.5×11</button>
-            <button class="btn" id="preset-1218">12×18</button>
-            <button class="btn ghost" id="swap-wh">Swap W/H</button>
-            <span>Units:</span>
-            <select id="units">
-              <option value="in">inches</option>
-              <option value="mm">millimeters</option>
-            </select>
-          </div>
-
-          <div class="card" style="margin-top:10px">
-            <h2>Sheet</h2>
-            <div class="row">
-              <label><span>Width</span><input id="sheetW" type="number" step="0.001" value="12"></label>
-              <label><span>Height</span><input id="sheetH" type="number" step="0.001" value="18"></label>
+          <div class="inputs-scroll">
+            <div class="toolbar no-print inputs-toolbar">
+              <button class="btn" id="preset-letter">Letter 8.5×11</button>
+              <button class="btn" id="preset-1218">12×18</button>
+              <button class="btn ghost" id="swap-wh">Swap W/H</button>
+              <span>Units:</span>
+              <select id="units">
+                <option value="in">inches</option>
+                <option value="mm">millimeters</option>
+              </select>
             </div>
-          </div>
 
-          <div class="card" style="margin-top:8px">
-            <h2>Document</h2>
-            <div class="row">
-              <label><span>Width</span><input id="docW" type="number" step="0.001" value="3.5"></label>
-              <label><span>Height</span><input id="docH" type="number" step="0.001" value="2"></label>
+            <div class="stack stack-sm">
+              <div class="card">
+                <h2>Sheet</h2>
+                <div class="row">
+                  <label><span>Width</span><input id="sheetW" type="number" step="0.001" value="12"></label>
+                  <label><span>Height</span><input id="sheetH" type="number" step="0.001" value="18"></label>
+                </div>
+              </div>
+
+              <div class="card">
+                <h2>Document</h2>
+                <div class="row">
+                  <label><span>Width</span><input id="docW" type="number" step="0.001" value="3.5"></label>
+                  <label><span>Height</span><input id="docH" type="number" step="0.001" value="2"></label>
+                </div>
+              </div>
+
+              <div class="card">
+                <h2>Gutter</h2>
+                <div class="row">
+                  <label><span>Horizontal</span><input id="gutH" type="number" step="0.001" value="0.125"></label>
+                  <label><span>Vertical</span><input id="gutV" type="number" step="0.001" value="0.125"></label>
+                </div>
+              </div>
+
+              <div class="card">
+                <h2>Docs (limit)</h2>
+                <div class="row">
+                  <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" placeholder="auto"></label>
+                  <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" placeholder="auto"></label>
+                </div>
+              </div>
+
+              <div class="card">
+                <h2>Margins (inside printable)</h2>
+                <div class="row4">
+                  <label><span>Top</span><input id="mTop" type="number" step="0.001" value="" placeholder="auto"></label>
+                  <label><span>Right</span><input id="mRight" type="number" step="0.001" value="" placeholder="auto"></label>
+                  <label><span>Bottom</span><input id="mBottom" type="number" step="0.001" value="" placeholder="auto"></label>
+                  <label><span>Left</span><input id="mLeft" type="number" step="0.001" value="" placeholder="auto"></label>
+                </div>
+              </div>
+
+              <div class="card">
+                <h2>Non‑Printable Edge</h2>
+                <div class="row4">
+                  <label><span>Top</span><input id="npTop" type="number" step="0.001" value="0.0625"></label>
+                  <label><span>Right</span><input id="npRight" type="number" step="0.001" value="0.0625"></label>
+                  <label><span>Bottom</span><input id="npBottom" type="number" step="0.001" value="0.0625"></label>
+                  <label><span>Left</span><input id="npLeft" type="number" step="0.001" value="0.0625"></label>
+                </div>
+              </div>
+
+              <div class="toolbar no-print inputs-actions">
+                <button class="btn primary" id="calcBtn">Update Preview</button>
+                <button class="btn" id="resetBtn">Reset</button>
+                <span class="k" id="status"></span>
+              </div>
             </div>
-          </div>
-
-          <div class="card" style="margin-top:8px">
-            <h2>Gutter</h2>
-            <div class="row">
-              <label><span>Horizontal</span><input id="gutH" type="number" step="0.001" value="0.125"></label>
-              <label><span>Vertical</span><input id="gutV" type="number" step="0.001" value="0.125"></label>
-            </div>
-          </div>
-
-          <div class="card" style="margin-top:8px">
-            <h2>Docs (limit)</h2>
-            <div class="row">
-              <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" placeholder="auto"></label>
-              <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" placeholder="auto"></label>
-            </div>
-          </div>
-
-          <div class="card" style="margin-top:8px">
-            <h2>Margins (inside printable)</h2>
-            <div class="row4">
-              <label><span>Top</span><input id="mTop" type="number" step="0.001" value="" placeholder="auto"></label>
-              <label><span>Right</span><input id="mRight" type="number" step="0.001" value="" placeholder="auto"></label>
-              <label><span>Bottom</span><input id="mBottom" type="number" step="0.001" value="" placeholder="auto"></label>
-              <label><span>Left</span><input id="mLeft" type="number" step="0.001" value="" placeholder="auto"></label>
-            </div>
-          </div>
-
-          <div class="card" style="margin-top:8px">
-            <h2>Non‑Printable Edge</h2>
-            <div class="row4">
-              <label><span>Top</span><input id="npTop" type="number" step="0.001" value="0.0625"></label>
-              <label><span>Right</span><input id="npRight" type="number" step="0.001" value="0.0625"></label>
-              <label><span>Bottom</span><input id="npBottom" type="number" step="0.001" value="0.0625"></label>
-              <label><span>Left</span><input id="npLeft" type="number" step="0.001" value="0.0625"></label>
-            </div>
-          </div>
-
-          <div class="toolbar no-print">
-            <button class="btn primary" id="calcBtn">Update Preview</button>
-            <button class="btn" id="resetBtn">Reset</button>
-            <span class="k" id="status"></span>
           </div>
         </aside>
 


### PR DESCRIPTION
## Summary
- replace inline card spacing with shared stack utilities and group inputs inside a scroll container
- make the two-column shell responsive with a minmax template and mobile breakpoint
- add sticky toolbar behavior and more flexible row grids to keep controls accessible on narrow screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690bb4b73bcc832481a2fa3a197d4f73