### PR TITLE
Keep preview visible and move details to tabs

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -132,6 +132,18 @@ h3 {
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
 }
 
+.output-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.output-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -264,6 +276,10 @@ select {
   border-bottom: 1px solid #1f2430;
   margin: -14px -14px 10px;
   padding: 0 10px;
+}
+
+.output-tabs {
+  margin: 0 -14px 10px;
 }
 
 .tab {

--- a/public/index.html
+++ b/public/index.html
@@ -88,17 +88,26 @@
         </aside>
 
         <!-- RIGHT: Output/Tabs -->
-        <main class="panel">
-          <nav class="tabbar no-print">
-            <div class="tab" data-tab="summary">Summary</div>
-            <div class="tab active" data-tab="preview">Grid Preview</div>
+        <main class="panel output-panel">
+          <div class="output-preview">
+            <div class="preview"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
+            <div class="legend no-print">
+              <span><i class="dot grid"></i>Layout Area</span>
+              <span><i class="dot doc"></i>Documents</span>
+              <span><i class="dot cut"></i>Cut/Slit Lines</span>
+              <span><i class="dot score"></i>Scores</span>
+            </div>
+          </div>
+
+          <nav class="tabbar no-print output-tabs">
+            <div class="tab active" data-tab="summary">Summary</div>
             <div class="tab" data-tab="finishing">Cuts / Slits</div>
             <div class="tab" data-tab="scores">Scores</div>
             <div class="tab" data-tab="print">Print</div>
           </nav>
 
           <div class="tabpanes">
-            <section id="tab-summary">
+            <section id="tab-summary" class="active">
               <div class="summary">
                 <div class="card"><h3>Counts</h3>
                   <div>Across: <span class="v" id="vAcross">—</span></div>
@@ -114,16 +123,6 @@
                   <div>Used W/H: <span class="v" id="vUsed">—</span></div>
                   <div>Trailing W/H: <span class="v" id="vTrail">—</span></div>
                 </div>
-              </div>
-            </section>
-
-            <section id="tab-preview" class="active">
-              <div class="preview"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
-              <div class="legend no-print">
-                <span><i class="dot grid"></i>Layout Area</span>
-                <span><i class="dot doc"></i>Documents</span>
-                <span><i class="dot cut"></i>Cut/Slit Lines</span>
-                <span><i class="dot score"></i>Scores</span>
               </div>
             </section>
 


### PR DESCRIPTION
## Summary
- keep the preview visible at all times by moving it outside the tab content area
- adjust the tabs to focus on the summary/finishing/scores/print sections only
- add layout styling to space the always-on preview and the detail tabs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690bb5ddd81c832497b69542400630a6