### PR TITLE
Rename non-printable card heading to area

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -112,7 +112,7 @@
                   </div>
 
                   <div class="card">
-                    <h2>Non‑Printable Edge</h2>
+                    <h2>Non‑Printable Area</h2>
                     <div class="row4">
                       <label><span>Top</span><input id="npTop" type="number" step="0.001" value="0.0625"></label>
                       <label><span>Right</span><input id="npRight" type="number" step="0.001" value="0.0625"></label>


### PR DESCRIPTION
## Summary
- update the layout inputs card heading to read "Non‑Printable Area"
- ensure non-printable terminology consistently references area

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c0289f3d083249dbc1b44189c8a59