### PR TITLE
Add preview layer toggles

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -271,6 +271,40 @@ select {
   margin: 0 0 6px;
 }
 
+.preview-toolbar {
+  justify-content: flex-start;
+  padding: 8px 10px;
+  background: #11141b;
+  border: 1px solid #1f2430;
+  border-radius: 10px;
+  margin: 0;
+}
+
+.preview-toolbar label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid #1f2430;
+  background: #0d1117;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.preview-toolbar label:hover {
+  border-color: #334155;
+  background: #131926;
+}
+
+.preview-toolbar input[type="checkbox"] {
+  margin: 0;
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
 .btn {
   appearance: none;
   border: 1px solid #263041;

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,24 @@
 
       <section class="panel preview-panel">
         <div class="output-preview">
+          <div class="toolbar preview-toolbar no-print">
+            <label>
+              <input class="layer-toggle" type="checkbox" data-layer="layout" checked />
+              <span>Layout Area</span>
+            </label>
+            <label>
+              <input class="layer-toggle" type="checkbox" data-layer="docs" checked />
+              <span>Documents</span>
+            </label>
+            <label>
+              <input class="layer-toggle" type="checkbox" data-layer="cuts" checked />
+              <span>Cuts / Slits</span>
+            </label>
+            <label>
+              <input class="layer-toggle" type="checkbox" data-layer="scores" checked />
+              <span>Scores</span>
+            </label>
+          </div>
           <div class="preview"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
           <div class="legend no-print">
             <span><i class="dot grid"></i>Layout Area</span>


### PR DESCRIPTION
## Summary
- add a preview toolbar with layer checkboxes to control layout, document, cut/slit, and score visibility
- style the toolbar to match the existing dark theme
- tag generated SVG elements with layer metadata and wire up checkbox listeners to toggle visibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c035653348324a3a5052d42caddb8