### PR TITLE
Convert print tab to static summary view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,19 +186,20 @@
           <section id="tab-print">
             <div class="row">
               <div class="card">
-                <h3>Print Summary</h3>
-                <p class="muted">Choose a page size. We inject an <code>@page</code> rule, then open print.</p>
-                <div class="toolbar no-print"><button class="btn" id="btnPrintLetter">Print — Letter</button><button class="btn" id="btnPrint1218">Print — 12×18</button></div>
-                <ul>
-                  <li><b>Sheet</b>: <span id="pSheet">—</span></li>
-                  <li><b>Doc</b>: <span id="pDoc">—</span></li>
-                  <li><b>Counts</b>: <span id="pCounts">—</span></li>
-                  <li><b>Gutter</b>: <span id="pGutter">—</span></li>
-                  <li><b>Margins</b>: <span id="pMargins">—</span></li>
-                </ul>
+                <h3>Summary Snapshot</h3>
+                <p class="muted">Review the calculated layout details without opening a print dialog.</p>
+                <div class="summary">
+                  <div>Sheet: <span class="v" id="pSheet">—</span></div>
+                  <div>Doc: <span class="v" id="pDoc">—</span></div>
+                  <div>Counts: <span class="v" id="pCounts">—</span></div>
+                  <div>Gutter: <span class="v" id="pGutter">—</span></div>
+                  <div>Margins: <span class="v" id="pMargins">—</span></div>
+                </div>
               </div>
-              <div class="card"><h3>What prints?</h3>
-                <p class="muted">Summary cards and finishing tables. Inputs/tabs are hidden.</p>
+              <div class="card">
+                <h3>What prints?</h3>
+                <p class="muted">Summary cards and finishing tables remain available for browser printing.</p>
+                <p class="muted">Use this tab as a quick reference for layout specs shared with production.</p>
               </div>
             </div>
             <div class="print-only" id="printTables"></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -469,25 +469,6 @@ $('#units').addEventListener('change', (e) => {
 $('#calcBtn').addEventListener('click', update);
 $('#resetBtn').addEventListener('click', () => location.reload());
 
-function withPageSize(wIn, hIn) {
-  const id = 'page-size-style';
-  let tag = document.getElementById(id);
-  if (!tag) {
-    tag = document.createElement('style');
-    tag.id = id;
-    document.head.appendChild(tag);
-  }
-  tag.textContent = `@page{ size: ${wIn}in ${hIn}in; margin: 12mm; }`;
-}
-$('#btnPrintLetter').addEventListener('click', () => {
-  withPageSize(8.5, 11);
-  window.print();
-});
-$('#btnPrint1218').addEventListener('click', () => {
-  withPageSize(12, 18);
-  window.print();
-});
-
 $('#applyScores').addEventListener('click', update);
 
 document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- replace the Print tab buttons with static summary placeholders to keep the data visible without triggering print dialogs
- remove the page size helper and print event listeners now that the tab only surfaces summary data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690c036286448324be4a88b752b00cc3