### PR TITLE
Add score presets and restructure scores tab layout

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -329,6 +329,12 @@ select {
   background: transparent;
 }
 
+.btn.is-active {
+  border-color: var(--accent);
+  background: #112024;
+  color: var(--accent);
+}
+
 /* =============================================
  * Tabs & Cards
  * ---------------------------------------------
@@ -357,6 +363,116 @@ select {
 .tab.active {
   color: var(--text);
   border-color: var(--accent);
+}
+
+.scores-pane {
+  --stack-gap: 18px;
+}
+
+.score-card {
+  --stack-gap: 16px;
+}
+
+.score-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #1f2430;
+}
+
+.score-card-title p {
+  margin: 0;
+  max-width: 460px;
+}
+
+.score-presets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.score-presets .btn {
+  min-width: 90px;
+  text-align: center;
+}
+
+.score-inputs {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.score-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.score-field label {
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 8px;
+}
+
+.score-field label span {
+  font-size: 0.85rem;
+  color: #cbd5e1;
+}
+
+.score-field label input {
+  width: 100%;
+  text-align: left;
+}
+
+.score-field label input.is-locked {
+  background: #111821;
+  border-color: #253043;
+  color: #cbd5e1;
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+
+.score-hint {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.score-actions {
+  margin: 0;
+  justify-content: space-between;
+}
+
+.score-actions .muted {
+  font-size: 0.85rem;
+}
+
+.score-table-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.score-table-card {
+  --stack-gap: 12px;
+}
+
+.score-table-card p {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 680px) {
+  .score-card-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .score-presets {
+    justify-content: flex-start;
+  }
 }
 
 .tabpanes > section {

--- a/public/index.html
+++ b/public/index.html
@@ -181,22 +181,55 @@
           </section>
 
           <section id="tab-scores">
-            <div class="card" style="margin-bottom:10px">
-              <h3>Score Offsets (relative within document)</h3>
-              <div class="row">
-                <label title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)"><span>Vertical offsets</span>
-                  <input id="scoresV" type="text" value="" placeholder="e.g., 0.5"></label>
-                <label title="CSV, 0–1"><span>Horizontal offsets</span>
-                  <input id="scoresH" type="text" value="" placeholder="e.g., 0.5"></label>
+            <div class="scores-pane stack">
+              <div class="card stack score-card">
+                <div class="score-card-header">
+                  <div class="score-card-title">
+                    <h3>Score Planning</h3>
+                    <p class="muted">Offsets are normalized to each document. Choose a preset for common folds or switch to custom entry to fine-tune the layout.</p>
+                  </div>
+                  <div class="score-presets no-print" role="group" aria-label="Score presets">
+                    <button class="btn" id="scorePresetBifold" type="button">Bifold</button>
+                    <button class="btn" id="scorePresetTrifold" type="button">Trifold</button>
+                    <button class="btn" id="scorePresetCustom" type="button">Custom</button>
+                  </div>
+                </div>
+                <div class="score-inputs">
+                  <div class="score-field stack-sm">
+                    <label class="score-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
+                      <span>Vertical offsets</span>
+                      <input id="scoresV" type="text" value="" placeholder="e.g., 0.5" />
+                    </label>
+                    <p class="muted score-hint">Positions lines that run top-to-bottom across the sheet. Values are relative to the document width.</p>
+                  </div>
+                  <div class="score-field stack-sm">
+                    <label class="score-label" for="scoresH" title="CSV, 0–1">
+                      <span>Horizontal offsets</span>
+                      <input id="scoresH" type="text" value="" placeholder="e.g., 0.5" />
+                    </label>
+                    <p class="muted score-hint">Positions lines that run left-to-right across the sheet. Values are relative to the document height.</p>
+                  </div>
+                </div>
+                <div class="score-actions toolbar no-print">
+                  <button class="btn primary" id="applyScores" type="button">Apply Scores</button>
+                  <span class="muted">Leave fields blank to omit scores.</span>
+                </div>
               </div>
-              <div class="toolbar no-print"><button class="btn" id="applyScores">Apply Scores</button><span class="muted">Leave blank for no scores</span></div>
-            </div>
-            <div class="grid" style="grid-template-columns:1fr 1fr">
-              <div class="card"><h3>Scores (Y)</h3>
-                <table class="table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-              </div>
-              <div class="card"><h3>Scores (X)</h3>
-                <table class="table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+              <div class="grid score-table-grid">
+                <div class="card stack score-table-card">
+                  <div>
+                    <h3>Scores (Y)</h3>
+                    <p class="muted">Horizontal runs positioned along the sheet height.</p>
+                  </div>
+                  <table class="table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                </div>
+                <div class="card stack score-table-card">
+                  <div>
+                    <h3>Scores (X)</h3>
+                    <p class="muted">Vertical runs positioned along the sheet width.</p>
+                  </div>
+                  <table class="table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                </div>
               </div>
             </div>
           </section>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -481,6 +481,88 @@ $('#gut-none').addEventListener('click', () => setGutterPreset(0, 0));
 $('#gut-eighth').addEventListener('click', () => setGutterPreset(0.125, 0.125));
 $('#gut-3125x67').addEventListener('click', () => setGutterPreset(0.3125, 0.67));
 $('#gut-1inch').addEventListener('click', () => setGutterPreset(1, 1));
+
+const scorePresetButtons = {
+  bifold: $('#scorePresetBifold'),
+  trifold: $('#scorePresetTrifold'),
+  custom: $('#scorePresetCustom'),
+};
+const verticalScoreInput = $('#scoresV');
+const SCORE_PRESETS = {
+  bifold: [0.5],
+  trifold: [1 / 3, 2 / 3],
+};
+
+const formatScoreOffset = (value) => {
+  const fixed = Number(value || 0).toFixed(4);
+  const trimmed = fixed.replace(/0+$/, '').replace(/\.$/, '');
+  return trimmed === '' ? '0' : trimmed;
+};
+
+function setVerticalScoreOffsets(offsets = []) {
+  if (!verticalScoreInput) return;
+  if (!Array.isArray(offsets) || offsets.length === 0) {
+    verticalScoreInput.value = '';
+    return;
+  }
+  verticalScoreInput.value = offsets.map(formatScoreOffset).join(', ');
+}
+
+function lockVerticalScoreInput(lock, presetKey) {
+  if (!verticalScoreInput) return;
+  if (lock) {
+    verticalScoreInput.setAttribute('readonly', 'true');
+    verticalScoreInput.classList.add('is-locked');
+    if (presetKey) verticalScoreInput.dataset.preset = presetKey;
+  } else {
+    verticalScoreInput.removeAttribute('readonly');
+    verticalScoreInput.classList.remove('is-locked');
+    delete verticalScoreInput.dataset.preset;
+  }
+}
+
+function setScorePresetState(activeKey) {
+  Object.entries(scorePresetButtons).forEach(([key, btn]) => {
+    if (!btn) return;
+    const isActive = key === activeKey;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+scorePresetButtons.bifold?.addEventListener('click', () => {
+  setVerticalScoreOffsets(SCORE_PRESETS.bifold);
+  lockVerticalScoreInput(true, 'bifold');
+  setScorePresetState('bifold');
+  update();
+  status('Bifold score preset applied');
+});
+
+scorePresetButtons.trifold?.addEventListener('click', () => {
+  setVerticalScoreOffsets(SCORE_PRESETS.trifold);
+  lockVerticalScoreInput(true, 'trifold');
+  setScorePresetState('trifold');
+  update();
+  status('Trifold score preset applied');
+});
+
+scorePresetButtons.custom?.addEventListener('click', () => {
+  lockVerticalScoreInput(false);
+  setScorePresetState('custom');
+  verticalScoreInput?.focus();
+  status('Custom score entry enabled');
+});
+
+if (verticalScoreInput) {
+  ['input', 'change'].forEach((evt) =>
+    verticalScoreInput.addEventListener(evt, () => {
+      if (verticalScoreInput.readOnly) return;
+      setScorePresetState('custom');
+    })
+  );
+}
+
+setScorePresetState('custom');
 const UNIT_PRECISION = { in: 3, mm: 2 };
 const numericInputSelectors = [
   '#sheetW',


### PR DESCRIPTION
## Summary
- restructure the Scores tab to group presets, inputs, and readouts with a clearer hierarchy
- add Bifold, Trifold, and Custom preset handling that updates vertical score offsets and preview rendering
- style the new score controls so locked inputs and active presets are visually distinct

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690c05216f6c8324986db0419802ae52