### PR TITLE
Ensure sheet outline renders independently of layout layer

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -484,7 +484,7 @@ function drawSVG(layout, fin) {
     }
     svg.appendChild(l);
   };
-  R(0, 0, layout.sheet.rawWidth, layout.sheet.rawHeight, { stroke: "#334155", layer: "layout" });
+  R(0, 0, layout.sheet.rawWidth, layout.sheet.rawHeight, { stroke: "#334155" });
   R(layout.layoutArea.originX, layout.layoutArea.originY, layout.layoutArea.width, layout.layoutArea.height, {
     stroke: "#26323e",
     layer: "layout",


### PR DESCRIPTION
## Summary
- stop assigning the sheet outline rectangle to the layout layer in the SVG renderer
- keep the layout toggle limited to the inner layout area while the sheet outline always displays

## Testing
- manual verification by toggling the Layout Area checkbox in the preview

------
https://chatgpt.com/codex/tasks/task_e_690c09fd31ec832481a65782110bc551