### PR TITLE
Add perforation toggle for score measurements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -228,14 +228,14 @@
                     <h3>Scores (Y)</h3>
                     <p class="muted">Horizontal runs positioned along the sheet height.</p>
                   </div>
-                  <table class="table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                  <table class="table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th><th>Display as perforation</th></tr></thead><tbody></tbody></table>
                 </div>
                 <div class="card stack score-table-card">
                   <div>
                     <h3>Scores (X)</h3>
                     <p class="muted">Vertical runs positioned along the sheet width.</p>
                   </div>
-                  <table class="table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                  <table class="table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th><th>Display as perforation</th></tr></thead><tbody></tbody></table>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a persistent perforation state for score measurements with table checkboxes
- render perforated score lines as dashed strokes in the preview and update score table headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c0ac72fe483248bd319c53e545ddc