### PR TITLE
Add score offset swap control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -218,6 +218,7 @@
                   </div>
                 </div>
                 <div class="score-actions toolbar no-print">
+                  <button class="btn" id="swapScoreOffsets" type="button">Swap vertical ↔ horizontal offsets</button>
                   <button class="btn primary" id="applyScores" type="button">Apply Scores</button>
                   <span class="muted">Leave fields blank to omit scores.</span>
                 </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -717,6 +717,23 @@ function setScorePresetState(buttons, activeKey) {
 const setVerticalPresetState = (key) => setScorePresetState(verticalScorePresetButtons, key);
 const setHorizontalPresetState = (key) => setScorePresetState(horizontalScorePresetButtons, key);
 
+function swapScoreOffsets() {
+  if (!verticalScoreInput || !horizontalScoreInput) return;
+  const verticalOffsets = parseOffsets(verticalScoreInput.value);
+  const horizontalOffsets = parseOffsets(horizontalScoreInput.value);
+
+  lockVerticalScoreInput(false);
+  lockHorizontalScoreInput(false);
+  setVerticalPresetState('custom');
+  setHorizontalPresetState('custom');
+
+  setVerticalScoreOffsets(horizontalOffsets);
+  setHorizontalScoreOffsets(verticalOffsets);
+
+  update();
+  status('Swapped vertical and horizontal score offsets');
+}
+
 verticalScorePresetButtons.bifold?.addEventListener('click', () => {
   setVerticalScoreOffsets(SCORE_PRESETS.bifold);
   lockVerticalScoreInput(true, 'bifold');
@@ -773,6 +790,8 @@ horizontalScorePresetButtons.custom?.addEventListener('click', () => {
   update();
   status('Horizontal custom score entry enabled');
 });
+
+$('#swapScoreOffsets')?.addEventListener('click', swapScoreOffsets);
 
 if (horizontalScoreInput) {
   ['input', 'change'].forEach((evt) =>


### PR DESCRIPTION
## Summary
- add a swap button to the score actions toolbar for exchanging vertical and horizontal offsets
- implement swap logic that unlocks presets, updates inputs, refreshes the view, and reports status

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c0c5854248324871e85778f8e2762