### PR TITLE
Rename layout tab to inputs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
 
       <main class="panel tab-panel">
         <nav class="tabbar no-print output-tabs">
-          <div class="tab active" data-tab="layout">Layout</div>
+          <div class="tab active" data-tab="inputs">Inputs</div>
           <div class="tab" data-tab="summary">Summary</div>
           <div class="tab" data-tab="finishing">Cuts / Slits</div>
           <div class="tab" data-tab="scores">Scores</div>
@@ -54,10 +54,10 @@
         </nav>
 
         <div class="tabpanes">
-          <section id="tab-layout" class="active">
+          <section id="tab-inputs" class="active">
             <div class="layout-pane">
               <div class="layout-header">
-                <h2>Layout Inputs</h2>
+                <h2>Input Controls</h2>
                 <p class="muted">Define the sheet, document, and safety settings to drive the preview.</p>
               </div>
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -637,15 +637,26 @@ function drawSVG(layout, fin) {
 // ------------------------------------------------------------
 // 4. Event bindings
 // ------------------------------------------------------------
-$$('.tab').forEach((t) =>
-  t.addEventListener('click', () => {
-    $$('.tab').forEach((x) => x.classList.remove('active'));
-    t.classList.add('active');
-    const target = t.dataset.tab;
-    $$('.tabpanes>section').forEach((s) => s.classList.remove('active'));
-    document.querySelector(`#tab-${target}`).classList.add('active');
-  })
-);
+const DEFAULT_TAB_KEY = 'inputs';
+
+function activateTab(targetKey = DEFAULT_TAB_KEY) {
+  const requestedTab = $(`.tab[data-tab='${targetKey}']`);
+  const requestedPane = document.querySelector(`#tab-${targetKey}`);
+  const fallbackTab = $(`.tab[data-tab='${DEFAULT_TAB_KEY}']`);
+  const fallbackPane = document.querySelector(`#tab-${DEFAULT_TAB_KEY}`);
+  const tabToActivate = requestedTab ?? fallbackTab;
+  const paneToActivate = requestedPane ?? fallbackPane;
+  if (!tabToActivate || !paneToActivate) return;
+  $$('.tab').forEach((x) => x.classList.remove('active'));
+  $$('.tabpanes>section').forEach((s) => s.classList.remove('active'));
+  tabToActivate.classList.add('active');
+  paneToActivate.classList.add('active');
+}
+
+$$('.tab').forEach((t) => t.addEventListener('click', () => activateTab(t.dataset.tab)));
+
+const initiallyActiveTab = document.querySelector('.tab.active');
+activateTab(initiallyActiveTab ? initiallyActiveTab.dataset.tab : DEFAULT_TAB_KEY);
 
 $$('.layer-toggle').forEach((input) => {
   const layer = input.dataset.layer;


### PR DESCRIPTION
## Summary
- retitle the primary navigation tab and section to "Inputs" for clearer labeling
- update tab activation logic to use the new inputs key and provide a safe fallback when switching panes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690c1259879c8324b7826f3bc3c22008