### PR TITLE
Replace preset buttons with dropdowns

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -77,8 +77,12 @@
                   <div class="card">
                     <h2>Sheet</h2>
                     <div class="toolbar no-print">
-                      <button class="btn" id="sheet-1218">12×18</button>
-                      <button class="btn" id="sheet-1319">13×19</button>
+                      <label>
+                        <span class="muted">Preset</span>
+                        <select id="sheetPresetSelect" class="preset-select">
+                          <option value="">Choose a sheet preset…</option>
+                        </select>
+                      </label>
                     </div>
                     <div class="row">
                       <label><span>Width</span><input id="sheetW" type="number" step="0.25" value="12"></label>
@@ -89,10 +93,12 @@
                   <div class="card">
                     <h2>Document</h2>
                     <div class="toolbar no-print">
-                      <button class="btn" id="doc-35x2">3.5×2</button>
-                      <button class="btn" id="doc-8511">8.5×11</button>
-                      <button class="btn" id="doc-55x85">5.5×8.5</button>
-                      <button class="btn" id="doc-35x4">3.5×4</button>
+                      <label>
+                        <span class="muted">Preset</span>
+                        <select id="documentPresetSelect" class="preset-select">
+                          <option value="">Choose a document preset…</option>
+                        </select>
+                      </label>
                     </div>
                     <div class="row">
                       <label><span>Width</span><input id="docW" type="number" step="0.125" value="3.5"></label>
@@ -103,10 +109,12 @@
                   <div class="card">
                     <h2>Gutter</h2>
                     <div class="toolbar no-print">
-                      <button class="btn" id="gut-none">No gutters</button>
-                      <button class="btn" id="gut-eighth">1/8″</button>
-                      <button class="btn" id="gut-3125x67">0.3125×0.67</button>
-                      <button class="btn" id="gut-1inch">1″</button>
+                      <label>
+                        <span class="muted">Preset</span>
+                        <select id="gutterPresetSelect" class="preset-select">
+                          <option value="">Choose a gutter preset…</option>
+                        </select>
+                      </label>
                     </div>
                     <div class="row">
                       <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" value="0.125"></label>
@@ -442,6 +450,6 @@
     </div>
 
     <script src="./js/layout-presets.js"></script>
-    <script src="./js/app.js"></script>
+    <script type="module" src="./js/app.js"></script>
   </body>
 </html>

--- a/public/js/input-presets.js
+++ b/public/js/input-presets.js
@@ -1,0 +1,134 @@
+export const sheetPresets = [
+  {
+    id: 'sheet-1218',
+    label: '12×18 in',
+    width: 12,
+    height: 18,
+    systems: ['imperial'],
+  },
+  {
+    id: 'sheet-1319',
+    label: '13×19 in',
+    width: 13,
+    height: 19,
+    systems: ['imperial'],
+  },
+  {
+    id: 'sheet-a3',
+    label: 'A3 (297×420 mm)',
+    width: 11.69291,
+    height: 16.53543,
+    systems: ['metric'],
+  },
+  {
+    id: 'sheet-sra3',
+    label: 'SRA3 (320×450 mm)',
+    width: 12.59843,
+    height: 17.71654,
+    systems: ['metric'],
+  },
+];
+
+export const documentPresets = [
+  {
+    id: 'doc-35x2',
+    label: '3.5×2 in (Business Card)',
+    width: 3.5,
+    height: 2,
+    systems: ['imperial'],
+  },
+  {
+    id: 'doc-8511',
+    label: '8.5×11 in (Letter)',
+    width: 8.5,
+    height: 11,
+    systems: ['imperial'],
+  },
+  {
+    id: 'doc-55x85',
+    label: '5.5×8.5 in',
+    width: 5.5,
+    height: 8.5,
+    systems: ['imperial'],
+  },
+  {
+    id: 'doc-35x4',
+    label: '3.5×4 in',
+    width: 3.5,
+    height: 4,
+    systems: ['imperial'],
+  },
+  {
+    id: 'doc-a5',
+    label: 'A5 (148×210 mm)',
+    width: 5.82677,
+    height: 8.26772,
+    systems: ['metric'],
+  },
+  {
+    id: 'doc-a6',
+    label: 'A6 (105×148 mm)',
+    width: 4.13386,
+    height: 5.82677,
+    systems: ['metric'],
+  },
+  {
+    id: 'doc-dl',
+    label: 'DL (99×210 mm)',
+    width: 3.89764,
+    height: 8.26772,
+    systems: ['metric'],
+  },
+];
+
+export const gutterPresets = [
+  {
+    id: 'gut-none',
+    label: 'No gutters',
+    width: 0,
+    height: 0,
+    systems: ['imperial', 'metric'],
+  },
+  {
+    id: 'gut-eighth',
+    label: '1/8″ (0.125 in)',
+    width: 0.125,
+    height: 0.125,
+    systems: ['imperial'],
+  },
+  {
+    id: 'gut-3125x67',
+    label: '0.3125×0.67 in',
+    width: 0.3125,
+    height: 0.67,
+    systems: ['imperial'],
+  },
+  {
+    id: 'gut-1inch',
+    label: '1″ (1.0 in)',
+    width: 1,
+    height: 1,
+    systems: ['imperial'],
+  },
+  {
+    id: 'gut-3mm',
+    label: '3 mm',
+    width: 0.11811,
+    height: 0.11811,
+    systems: ['metric'],
+  },
+  {
+    id: 'gut-5mm',
+    label: '5 mm',
+    width: 0.19685,
+    height: 0.19685,
+    systems: ['metric'],
+  },
+  {
+    id: 'gut-10mm',
+    label: '10 mm',
+    width: 0.3937,
+    height: 0.3937,
+    systems: ['metric'],
+  },
+];


### PR DESCRIPTION
## Summary
- centralize sheet, document, and gutter presets in a shared data module
- replace preset shortcut buttons with dropdowns driven from the shared data
- update the app logic to populate the selects, handle changes, and swap presets when units change

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c19c9d0908324808d0509d667d79e