### PR TITLE
Ensure numeric input steps follow unit selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -85,8 +85,8 @@
                       </label>
                     </div>
                     <div class="row">
-                      <label><span>Width</span><input id="sheetW" type="number" step="0.25" value="12"></label>
-                      <label><span>Height</span><input id="sheetH" type="number" step="0.25" value="18"></label>
+                      <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25" value="12"></label>
+                      <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25" value="18"></label>
                     </div>
                   </div>
 
@@ -101,8 +101,8 @@
                       </label>
                     </div>
                     <div class="row">
-                      <label><span>Width</span><input id="docW" type="number" step="0.125" value="3.5"></label>
-                      <label><span>Height</span><input id="docH" type="number" step="0.125" value="2"></label>
+                      <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125" value="3.5"></label>
+                      <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125" value="2"></label>
                     </div>
                   </div>
 
@@ -117,36 +117,36 @@
                       </label>
                     </div>
                     <div class="row">
-                      <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" value="0.125"></label>
-                      <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" value="0.125"></label>
+                      <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625" value="0.125"></label>
+                      <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625" value="0.125"></label>
                     </div>
                   </div>
 
                   <div class="card">
                     <h2>Docs (limit)</h2>
                     <div class="row">
-                      <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" placeholder="auto"></label>
-                      <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" placeholder="auto"></label>
+                      <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
+                      <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
                     </div>
                   </div>
 
                   <div class="card">
                     <h2>Margins (inside printable)</h2>
                     <div class="row4">
-                      <label><span>Top</span><input id="mTop" type="number" step="0.125" value="" placeholder="auto"></label>
-                      <label><span>Right</span><input id="mRight" type="number" step="0.125" value="" placeholder="auto"></label>
-                      <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" value="" placeholder="auto"></label>
-                      <label><span>Left</span><input id="mLeft" type="number" step="0.125" value="" placeholder="auto"></label>
+                      <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" value="" placeholder="auto"></label>
+                      <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" value="" placeholder="auto"></label>
+                      <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" value="" placeholder="auto"></label>
+                      <label><span>Left</span><input id="mLeft" type="number" step="0.125" data-inch-step="0.125" value="" placeholder="auto"></label>
                     </div>
                   </div>
 
                   <div class="card">
                     <h2>Non‑Printable Area</h2>
                     <div class="row4">
-                      <label><span>Top</span><input id="npTop" type="number" step="0.625" value="0.0625"></label>
-                      <label><span>Right</span><input id="npRight" type="number" step="0.625" value="0.0625"></label>
-                      <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" value="0.0625"></label>
-                      <label><span>Left</span><input id="npLeft" type="number" step="0.625" value="0.0625"></label>
+                      <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625" value="0.0625"></label>
+                      <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625" value="0.0625"></label>
+                      <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625" value="0.0625"></label>
+                      <label><span>Left</span><input id="npLeft" type="number" step="0.625" data-inch-step="0.625" value="0.0625"></label>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add inch-based data attributes to numeric controls so their base step/min metadata is preserved
- extend the unit conversion helpers to retune numeric input values and attributes on load and unit changes
- add a regression assertion that a units round-trip leaves numeric values and step settings unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c1b13c6bc8324b11cd61cc56e4dab