### PR TITLE
Refactor UI classes for clarity and documentation

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -57,7 +57,8 @@ h3 {
  * Grid helpers and panels that shape the main
  * calculator layout.
  * ============================================= */
-.wrap {
+/* This class wraps the entire calculator experience, establishing the page centering and stacking rhythm. */
+.layout-app-shell {
   max-width: 1280px;
   margin: 0 auto;
   padding: 16px 18px 24px;
@@ -67,38 +68,45 @@ h3 {
   gap: 18px;
 }
 
-.app-header {
+/* This class formats the top header section that introduces the calculator. */
+.layout-app-header {
   display: flex;
   flex-direction: column;
   gap: 4px;
   padding: 4px 6px 0;
 }
 
-.app-header p {
+/* This descendant rule limits header body copy width for readability. */
+.layout-app-header p {
   margin: 0;
   max-width: 640px;
 }
 
-.grid {
+/* This utility class creates grid layouts for cards and content groupings. */
+.layout-grid-group {
   display: grid;
   gap: 12px;
 }
 
-.stack {
+/* This utility class stacks children vertically with customizable spacing. */
+.layout-stack {
   display: flex;
   flex-direction: column;
   gap: var(--stack-gap, 12px);
 }
 
-.stack-sm {
+/* This modifier tightens spacing for compact stack layouts. */
+.layout-stack-compact {
   --stack-gap: 8px;
 }
 
-.stack .toolbar {
+/* This rule removes extra spacing when toolbars render inside stacked cards. */
+.layout-stack .control-toolbar, .layout-stack .visualizer-visibility-toggles {
   margin: 0;
 }
 
-.inputs-scroll {
+/* This container enables scrolling for the primary input controls while keeping layout flexible. */
+.input-scroll-container {
   flex: 1;
   min-height: 0;
   display: flex;
@@ -108,7 +116,8 @@ h3 {
   padding-right: 6px;
 }
 
-.inputs-toolbar {
+/* This toolbar anchors the unit selector at the top of the scrollable input area. */
+.input-unit-controls {
   position: sticky;
   top: 0;
   padding: 6px 0 10px;
@@ -118,7 +127,8 @@ h3 {
   margin: 0;
 }
 
-.inputs-toolbar::after {
+/* This pseudo-element draws a separator line beneath the sticky unit selector. */
+.input-unit-controls::after {
   content: "";
   position: absolute;
   inset: auto 0 0;
@@ -127,7 +137,8 @@ h3 {
   opacity: 0.6;
 }
 
-.panel {
+/* This class standardizes the chrome around the primary content groupings. */
+.content-section {
   background: var(--panel);
   border: 1px solid #222632;
   border-radius: 14px;
@@ -135,82 +146,107 @@ h3 {
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
 }
 
-.preview-panel {
+/* This class structures the visualizer section that houses the preview canvas and legend. */
+.sheet-preview-visualizer {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.tab-panel {
+/* This class governs the tabbed analysis section that follows the preview. */
+.output-details-section {
   display: flex;
   flex-direction: column;
   gap: 0;
 }
 
-.tab-panel .tabpanes {
+/* This rule ensures tab content stretches to fill available height for scrollable panes. */
+.output-details-section .output-tabpanel-collection {
   flex: 1;
   min-height: 0;
 }
 
-.layout-pane {
+/* This container groups the input cards and supporting descriptions. */
+.input-layout-panel {
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
-.layout-header p {
+/* This header styling keeps intro copy aligned with the pane layout. */
+.input-panel-header p {
   margin: 0;
   font-size: 0.95rem;
 }
 
-.layout-grid {
+/* This grid arranges configuration cards responsively based on available width. */
+.input-card-grid {
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.output-preview {
+/* This container stacks the preview canvas, its controls, and legend. */
+.sheet-preview-container {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.row {
+/* This grid arranges input fields into flexible, multi-column rows. */
+.input-field-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 8px;
 }
 
-.row4 {
+/* This variation supports four-up field clusters with narrower minimum widths. */
+.input-field-row-quad {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   gap: 8px;
 }
 
+/* This helper distributes form controls evenly based on available width. */
+.input-field-row-auto {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 6px;
+}
+
 @media (max-width: 900px) {
-  .inputs-scroll {
+  /* This adjustment relaxes scrolling on smaller screens for the input pane. */
+  .input-scroll-container {
     overflow: visible;
     padding-right: 0;
   }
 
-  .inputs-toolbar {
+  /* This removes the sticky behavior on narrow devices where it might obscure inputs. */
+  .input-unit-controls {
     position: static;
     box-shadow: none;
   }
 
-  .inputs-toolbar::after {
+  /* The separator is hidden when sticky behavior is removed. */
+  .input-unit-controls::after {
     display: none;
   }
 }
 
-.muted {
+/* =============================================
+ * Typography Helpers
+ * ---------------------------------------------
+ * Text utility classes for muted and numeric
+ * treatments shared across the UI.
+ * ============================================= */
+/* This utility softens copy for supporting descriptions and helper text. */
+.text-muted-detail {
   color: var(--muted);
 }
 
-.rowAuto {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 6px;
+/* This utility aligns inline values to a fixed numeric width for quick comparisons. */
+.text-metric-readout {
+  font-variant-numeric: tabular-nums;
 }
 
 /* =============================================
@@ -255,11 +291,8 @@ select {
   width: 100%;
 }
 
-.k {
-  font-variant-numeric: tabular-nums;
-}
-
-.toolbar {
+/* This base class standardizes horizontal control group layouts across the app. */
+.control-toolbar {
   display: flex;
   gap: 8px;
   align-items: center;
@@ -267,20 +300,48 @@ select {
   margin: 0.5rem 0 0;
 }
 
-.card > .toolbar {
+/* This rule removes extra spacing when toolbars appear directly inside cards. */
+.data-card > .control-toolbar {
   margin: 0 0 6px;
 }
 
-.preview-toolbar {
+/* This toolbar pins preset dropdowns within card headers for quick access. */
+.preset-selector-toolbar {
+  justify-content: flex-start;
+}
+
+/* This toolbar coordinates the primary action buttons for the input controls. */
+.input-action-toolbar {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+/* =============================================
+ * Preview Controls
+ * ---------------------------------------------
+ * Specific tooling for toggling layer visibility
+ * and presenting the preview canvas.
+ * ============================================= */
+/* This toolbar hosts the layer visibility checkboxes directly above the preview. */
+.visualizer-visibility-toggles {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0;
+}
+
+/* This modifier styles the preview toggle controls with a darker backdrop and padding. */
+.layer-visibility-toolbar {
   justify-content: flex-start;
   padding: 8px 10px;
   background: #11141b;
   border: 1px solid #1f2430;
   border-radius: 10px;
-  margin: 0;
 }
 
-.preview-toolbar label {
+/* These labels format each individual layer toggle option. */
+.layer-visibility-toolbar label {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -293,19 +354,28 @@ select {
   font-size: 0.9rem;
 }
 
-.preview-toolbar label:hover {
+/* Hover states highlight the label border to reinforce interactivity. */
+.layer-visibility-toolbar label:hover {
   border-color: #334155;
   background: #131926;
 }
 
-.preview-toolbar input[type="checkbox"] {
+/* Checkbox styling aligns with the neon accent of the preview. */
+.layer-visibility-toolbar input[type="checkbox"] {
   margin: 0;
   width: 16px;
   height: 16px;
   accent-color: var(--accent);
 }
 
-.btn {
+/* =============================================
+ * Buttons
+ * ---------------------------------------------
+ * Shared button styling for actions and toolbar
+ * affordances throughout the UI.
+ * ============================================= */
+/* This base button class unifies shape, padding, and neutral chroma across actions. */
+.action-button {
   appearance: none;
   border: 1px solid #263041;
   background: #0d1117;
@@ -315,21 +385,25 @@ select {
   cursor: pointer;
 }
 
-.btn:hover {
+/* Hover states slightly brighten the border for feedback. */
+.action-button:hover {
   border-color: #334155;
   background: #101522;
 }
 
-.btn.primary {
+/* This modifier emphasizes primary actions with teal accents. */
+.action-button-primary {
   border-color: #1f8a8a;
   background: #0e1b1b;
 }
 
-.btn.ghost {
+/* This variant keeps the button transparent for subtle inline actions. */
+.action-button-ghost {
   background: transparent;
 }
 
-.btn.is-active {
+/* This state class highlights the active button in toggle groups. */
+.action-button.is-active {
   border-color: var(--accent);
   background: #112024;
   color: var(--accent);
@@ -341,7 +415,8 @@ select {
  * Styles for the output area, including tabs,
  * summary cards, and supporting tables.
  * ============================================= */
-.tabbar {
+/* This navigation bar anchors the tab triggers above the output content. */
+.output-tab-navigation-bar {
   display: flex;
   gap: 6px;
   border-bottom: 1px solid #1f2430;
@@ -349,59 +424,69 @@ select {
   padding: 0 10px;
 }
 
-.output-tabs {
+/* This class constrains the navigation to the card's horizontal padding. */
+.output-tab-navigation {
   margin: 0 -14px 10px;
 }
 
-.tab {
+/* Each trigger functions as a pseudo-tab button for switching panes. */
+.output-tab-trigger {
   padding: 10px 12px;
   border-bottom: 2px solid transparent;
   color: #c0c6d4;
   cursor: pointer;
 }
 
-.tab.active {
+/* Active tabs pick up the accent color to indicate selection. */
+.output-tab-trigger.is-active {
   color: var(--text);
   border-color: var(--accent);
 }
 
-.scores-pane {
+/* This container stacks score planning panels and supplemental results. */
+.finishing-score-pane {
   display: flex;
   flex-direction: column;
   gap: 18px;
 }
 
-.score-layout {
+/* This layout splits inputs and results into columns for large screens. */
+.finishing-score-layout {
   display: grid;
   gap: 18px;
   grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
   align-items: start;
 }
 
-.score-column {
+/* Each column stacks cards in the scoring and perforation tabs. */
+.finishing-score-column {
   display: flex;
   flex-direction: column;
   gap: 18px;
 }
 
-.score-card-intro {
+/* This card introduces the scoring/perforation section with contextual copy. */
+.finishing-score-card-intro {
   --stack-gap: 8px;
 }
 
-.score-results {
+/* This modifier adds breathing room between result cards. */
+.finishing-score-results {
   gap: 16px;
 }
 
-.score-card {
+/* This base card adds vertical rhythm for score configuration forms. */
+.finishing-score-card {
   --stack-gap: 16px;
 }
 
-.score-card-vertical .score-card-title p,
-.score-card-horizontal .score-card-title p {
+/* Horizontal score cards allow wider headlines to wrap cleanly. */
+.finishing-score-card-horizontal .finishing-score-card-title p, .finishing-score-card-vertical .finishing-score-card-title p {
   max-width: none;
 }
 
-.score-card-header {
+/* This header aligns titles and preset buttons for score cards. */
+.finishing-score-card-header {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -411,47 +496,55 @@ select {
   border-bottom: 1px solid #1f2430;
 }
 
-.score-card-title p {
+/* This container limits explanatory copy to a comfortable width. */
+.finishing-score-card-title p {
   margin: 0;
   max-width: 460px;
 }
 
-.score-presets {
+/* This group arranges preset buttons adjacent to score headings. */
+.finishing-score-preset-group {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
 }
 
-.score-presets .btn {
+/* Preset buttons maintain a minimum width to keep labels legible. */
+.finishing-score-preset-group .action-button {
   min-width: 90px;
   text-align: center;
 }
 
-.score-field {
+/* This container stacks score input labels and helper copy. */
+.finishing-score-field {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.score-field label {
+/* Score labels switch to a column layout for multi-line instructions. */
+.finishing-score-field label {
   flex-direction: column;
   align-items: stretch;
   justify-content: flex-start;
   gap: 8px;
 }
 
-.score-field label span {
+/* Score labels inherit a smaller caption style for descriptors. */
+.finishing-score-field label span {
   font-size: 0.85rem;
   color: #cbd5e1;
 }
 
-.score-field label input {
+/* Inputs span the full width when editing score values. */
+.finishing-score-field label input {
   width: 100%;
   text-align: left;
 }
 
-.score-field label input.is-locked {
+/* Locked score inputs adopt a disabled palette to indicate read-only state. */
+.finishing-score-field label input.is-locked {
   background: #111821;
   border-color: #253043;
   color: #cbd5e1;
@@ -459,161 +552,177 @@ select {
   opacity: 0.85;
 }
 
-.score-hint {
+/* Helper text reinforces how values are interpreted. */
+.finishing-score-hint {
   margin: 0;
   font-size: 0.85rem;
 }
 
-.score-actions {
-  margin: 0;
+/* Action toolbars for score/perforation tabs span available width for buttons and copy. */
+.finishing-action-toolbar {
   justify-content: space-between;
 }
 
-.score-actions-card {
+/* This card removes default padding so the toolbar can hug the edges. */
+.finishing-action-card {
   padding: 0;
 }
 
-.score-actions-card .score-actions {
+/* Padding is reintroduced within the toolbar for comfortable spacing. */
+.finishing-action-card .finishing-action-toolbar {
   padding: 12px;
 }
 
-.score-actions .muted {
+/* Inline helper text inside action toolbars uses the muted tone. */
+.finishing-action-toolbar .text-muted-detail {
   font-size: 0.85rem;
 }
 
-.score-table-card {
+/* Result cards tighten spacing for summary tables and descriptions. */
+.finishing-score-table-card {
   --stack-gap: 12px;
 }
 
-.score-table-card p {
+/* Copy inside result cards uses a smaller type scale. */
+.finishing-score-table-card p {
   margin: 0;
   font-size: 0.85rem;
 }
 
-.score-results-grid {
+/* Result grids arrange tables responsively based on available width. */
+.finishing-score-results-grid {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 @media (max-width: 960px) {
-  .score-layout {
+  /* Score layouts collapse to a single column on mid-sized screens. */
+  .finishing-score-layout {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 680px) {
-  .score-card-header {
+  /* Score headers stack elements vertically on narrow devices. */
+  .finishing-score-card-header {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .score-presets {
+  /* Preset buttons left-align when stacked vertically. */
+  .finishing-score-preset-group {
     justify-content: flex-start;
   }
 }
 
-.tabpanes > section {
+/* This wrapper hides inactive tab panels until selected. */
+.output-tabpanel-collection > section {
   display: none;
 }
 
-.tabpanes > section.active {
+/* Active tab panels are revealed when their tab is selected. */
+.output-tabpanel-collection > section.is-active {
   display: block;
 }
 
-.summary {
+/* This grid displays key metrics in three columns. */
+.summary-metrics-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 10px;
 }
 
-.card {
+/* Cards provide a consistent surface for presenting grouped content. */
+.data-card {
   background: #0e1219;
   border: 1px solid #1c2230;
   border-radius: 12px;
   padding: 12px;
 }
 
-.card .v {
+/* Summary values use a bold tabular treatment for quick scanning. */
+.data-card .summary-metric-value {
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }
 
-.table {
+/* Data tables share a consistent column spacing and divider treatment. */
+.data-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-.table th,
-.table td {
+/* Table cell padding creates airy spacing for tabular data. */
+.data-table th, .data-table td {
   padding: 8px 10px;
   border-bottom: 1px dashed #223;
 }
 
-.table th {
+/* Table headers use a brighter tone to stand out from data rows. */
+.data-table th {
   text-align: left;
   color: #cbd5e1;
 }
 
+/* Interactive measurement rows change background on hover/selection to mirror preview cues. */
 .measurement-row {
   cursor: pointer;
   transition: background 0.18s ease, color 0.18s ease;
 }
 
+/* Focus outlines assist keyboard navigation within the tables. */
 .measurement-row:focus {
   outline: 1px solid var(--accent);
   outline-offset: -2px;
 }
 
-.measurement-row.is-hovered,
-.measurement-row.is-selected {
+/* Hover and selected states brighten the text color for readability. */
+.measurement-row.is-hovered, .measurement-row.is-selected {
   color: #e2e8f0;
 }
 
-.measurement-row[data-measure-type="cut"].is-hovered,
-.measurement-row[data-measure-type="slit"].is-hovered {
+/* Cut and slit rows adopt aqua tones to match the preview overlay. */
+.measurement-row[data-measure-type="cut"].is-hovered, .measurement-row[data-measure-type="slit"].is-hovered {
   background: rgba(34, 211, 238, 0.12);
 }
 
-.measurement-row[data-measure-type="cut"].is-selected,
-.measurement-row[data-measure-type="slit"].is-selected {
+/* Selected cut and slit rows deepen the aqua fill. */
+.measurement-row[data-measure-type="cut"].is-selected, .measurement-row[data-measure-type="slit"].is-selected {
   background: rgba(34, 211, 238, 0.22);
 }
 
-.measurement-row[data-measure-type="score-horizontal"].is-hovered,
-.measurement-row[data-measure-type="score-vertical"].is-hovered {
+/* Hover states for score rows use lavender to mirror their overlay color. */
+.measurement-row[data-measure-type="score-horizontal"].is-hovered, .measurement-row[data-measure-type="score-vertical"].is-hovered {
   background: rgba(167, 139, 250, 0.12);
 }
 
-.measurement-row[data-measure-type="score-horizontal"].is-selected,
-.measurement-row[data-measure-type="score-vertical"].is-selected {
+/* Selected score rows intensify the lavender shading. */
+.measurement-row[data-measure-type="score-horizontal"].is-selected, .measurement-row[data-measure-type="score-vertical"].is-selected {
   background: rgba(167, 139, 250, 0.22);
 }
 
+/* Preview measurement lines transition smoothly when interacted with from the tables. */
 .measurement-line {
   pointer-events: auto;
   transition: stroke 0.2s ease, stroke-width 0.2s ease, opacity 0.2s ease;
   opacity: 0.9;
 }
 
-.measurement-line.is-hovered,
-.measurement-line.is-selected {
+/* Hovered and selected lines thicken to confirm linkage with the table rows. */
+.measurement-line.is-hovered, .measurement-line.is-selected {
   stroke-width: 3;
   opacity: 1;
 }
 
-.measurement-line[data-measure-type="cut"].is-hovered,
-.measurement-line[data-measure-type="cut"].is-selected,
-.measurement-line[data-measure-type="slit"].is-hovered,
-.measurement-line[data-measure-type="slit"].is-selected {
+/* Cut and slit lines glow aqua when highlighted. */
+.measurement-line[data-measure-type="cut"].is-hovered, .measurement-line[data-measure-type="cut"].is-selected, .measurement-line[data-measure-type="slit"].is-hovered, .measurement-line[data-measure-type="slit"].is-selected {
   stroke: #67e8f9;
   filter: drop-shadow(0 0 4px rgba(103, 232, 249, 0.6));
 }
 
-.measurement-line[data-measure-type="score-horizontal"].is-hovered,
-.measurement-line[data-measure-type="score-horizontal"].is-selected,
-.measurement-line[data-measure-type="score-vertical"].is-hovered,
-.measurement-line[data-measure-type="score-vertical"].is-selected {
+/* Score lines glow lavender to mirror the measurement legend. */
+.measurement-line[data-measure-type="score-horizontal"].is-hovered, .measurement-line[data-measure-type="score-horizontal"].is-selected, .measurement-line[data-measure-type="score-vertical"].is-hovered, .measurement-line[data-measure-type="score-vertical"].is-selected {
   stroke: #c4b5fd;
   filter: drop-shadow(0 0 4px rgba(196, 181, 253, 0.6));
 }
@@ -624,7 +733,8 @@ select {
  * Visual display for the SVG preview and legend
  * describing key color codes.
  * ============================================= */
-.preview {
+/* This stage centers the SVG preview and provides a dark surround. */
+.sheet-preview-stage {
   background: #0b0d12;
   border: 1px solid #1b2030;
   border-radius: 12px;
@@ -634,7 +744,8 @@ select {
   min-height: 360px;
 }
 
-.legend {
+/* This legend lists the preview layer colors and their meanings. */
+.sheet-preview-legend {
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
@@ -643,7 +754,8 @@ select {
   color: #cbd5e1;
 }
 
-.dot {
+/* Each swatch displays the color associated with a preview layer. */
+.legend-color-swatch {
   display: inline-block;
   width: 12px;
   height: 12px;
@@ -651,19 +763,23 @@ select {
   margin-right: 6px;
 }
 
-.dot.grid {
+/* Swatch color for the layout grid boundary. */
+.legend-swatch-layout-area {
   background: #26323e;
 }
 
-.dot.doc {
+/* Swatch color for document outlines. */
+.legend-swatch-documents {
   background: #64748b;
 }
 
-.dot.cut {
+/* Swatch color for cut and slit indications. */
+.legend-swatch-cuts {
   background: #22d3ee;
 }
 
-.dot.score {
+/* Swatch color for score overlays. */
+.legend-swatch-scores {
   background: #a78bfa;
 }
 
@@ -679,24 +795,29 @@ select {
     color: #000;
   }
 
-  .no-print {
+  /* Elements with this class disappear from printed output. */
+  .print-hidden {
     display: none !important;
   }
 
-  .print-only {
+  /* Elements with this class are forced visible only during print. */
+  .print-only-content {
     display: block !important;
   }
 
-  .panel {
+  /* Panels shed their borders when printed for a cleaner page. */
+  .content-section {
     border: none;
     box-shadow: none;
   }
 
-  .wrap {
+  /* The page width restriction is lifted to use the full sheet. */
+  .layout-app-shell {
     max-width: none;
   }
 }
 
-.print-only {
+/* Print-only containers remain hidden during on-screen use. */
+.print-only-content {
   display: none;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -8,64 +8,64 @@
     <link rel="stylesheet" href="./css/style.css" />
   </head>
   <body>
-    <div class="wrap">
-      <header class="app-header">
+    <div class="layout-app-shell">
+      <header class="layout-app-header">
         <h1>Print Layout Calculator</h1>
-        <p class="muted">Plan your sheet, finishing, and print-ready outputs from a single workspace.</p>
+        <p class="text-muted-detail">Plan your sheet, finishing, and print-ready outputs from a single workspace.</p>
       </header>
 
-      <section class="panel preview-panel">
-        <div class="output-preview">
-          <div class="toolbar preview-toolbar no-print">
+      <section class="content-section sheet-preview-visualizer">
+        <div class="sheet-preview-container">
+          <div class="visualizer-visibility-toggles layer-visibility-toolbar print-hidden">
             <label>
-              <input class="layer-toggle" type="checkbox" data-layer="layout" checked />
+              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="layout" checked />
               <span>Layout Area</span>
             </label>
             <label>
-              <input class="layer-toggle" type="checkbox" data-layer="docs" checked />
+              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="docs" checked />
               <span>Documents</span>
             </label>
             <label>
-              <input class="layer-toggle" type="checkbox" data-layer="cuts" checked />
+              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="cuts" checked />
               <span>Cuts / Slits</span>
             </label>
             <label>
-              <input class="layer-toggle" type="checkbox" data-layer="scores" checked />
+              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="scores" checked />
               <span>Scores</span>
             </label>
           </div>
-          <div class="preview"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
-          <div class="legend no-print">
-            <span><i class="dot grid"></i>Layout Area</span>
-            <span><i class="dot doc"></i>Documents</span>
-            <span><i class="dot cut"></i>Cut/Slit Lines</span>
-            <span><i class="dot score"></i>Scores</span>
+          <div class="sheet-preview-stage"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
+          <div class="sheet-preview-legend print-hidden">
+            <span><i class="legend-color-swatch legend-swatch-layout-area"></i>Layout Area</span>
+            <span><i class="legend-color-swatch legend-swatch-documents"></i>Documents</span>
+            <span><i class="legend-color-swatch legend-swatch-cuts"></i>Cut/Slit Lines</span>
+            <span><i class="legend-color-swatch legend-swatch-scores"></i>Scores</span>
           </div>
         </div>
       </section>
 
-      <main class="panel tab-panel">
-        <nav class="tabbar no-print output-tabs">
-          <div class="tab active" data-tab="inputs">Inputs</div>
-          <div class="tab" data-tab="summary">Summary</div>
-          <div class="tab" data-tab="finishing">Cuts / Slits</div>
-          <div class="tab" data-tab="scores">Scores</div>
-          <div class="tab" data-tab="perforations">Perforations</div>
-          <div class="tab" data-tab="warnings">Warnings</div>
-          <div class="tab" data-tab="print">Print</div>
-          <div class="tab" data-tab="presets">Presets</div>
+      <main class="content-section output-details-section">
+        <nav class="output-tab-navigation-bar output-tab-navigation print-hidden">
+          <div class="output-tab-trigger is-active" data-tab="inputs">Inputs</div>
+          <div class="output-tab-trigger" data-tab="summary">Summary</div>
+          <div class="output-tab-trigger" data-tab="finishing">Cuts / Slits</div>
+          <div class="output-tab-trigger" data-tab="scores">Scores</div>
+          <div class="output-tab-trigger" data-tab="perforations">Perforations</div>
+          <div class="output-tab-trigger" data-tab="warnings">Warnings</div>
+          <div class="output-tab-trigger" data-tab="print">Print</div>
+          <div class="output-tab-trigger" data-tab="presets">Presets</div>
         </nav>
 
-        <div class="tabpanes">
-          <section id="tab-inputs" class="active">
-            <div class="layout-pane">
-              <div class="layout-header">
+        <div class="output-tabpanel-collection">
+          <section id="tab-inputs" class="is-active">
+            <div class="input-layout-panel">
+              <div class="input-panel-header">
                 <h2>Input Controls</h2>
-                <p class="muted">Define the sheet, document, and safety settings to drive the preview.</p>
+                <p class="text-muted-detail">Define the sheet, document, and safety settings to drive the preview.</p>
               </div>
 
-              <div class="inputs-scroll">
-                <div class="toolbar no-print inputs-toolbar">
+              <div class="input-scroll-container">
+                <div class="control-toolbar input-unit-controls print-hidden">
                   <span>Units:</span>
                   <select id="units">
                     <option value="in">inches</option>
@@ -73,66 +73,66 @@
                   </select>
                 </div>
 
-                <div class="layout-grid">
-                  <div class="card">
+                <div class="input-card-grid">
+                  <div class="data-card">
                     <h2>Sheet</h2>
-                    <div class="toolbar no-print">
+                    <div class="control-toolbar preset-selector-toolbar print-hidden">
                       <label>
-                        <span class="muted">Preset</span>
-                        <select id="sheetPresetSelect" class="preset-select">
+                        <span class="text-muted-detail">Preset</span>
+                        <select id="sheetPresetSelect" class="preset-selector-control">
                           <option value="">Choose a sheet preset…</option>
                         </select>
                       </label>
                     </div>
-                    <div class="row">
+                    <div class="input-field-row">
                       <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25" value="12"></label>
                       <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25" value="18"></label>
                     </div>
                   </div>
 
-                  <div class="card">
+                  <div class="data-card">
                     <h2>Document</h2>
-                    <div class="toolbar no-print">
+                    <div class="control-toolbar preset-selector-toolbar print-hidden">
                       <label>
-                        <span class="muted">Preset</span>
-                        <select id="documentPresetSelect" class="preset-select">
+                        <span class="text-muted-detail">Preset</span>
+                        <select id="documentPresetSelect" class="preset-selector-control">
                           <option value="">Choose a document preset…</option>
                         </select>
                       </label>
                     </div>
-                    <div class="row">
+                    <div class="input-field-row">
                       <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125" value="3.5"></label>
                       <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125" value="2"></label>
                     </div>
                   </div>
 
-                  <div class="card">
+                  <div class="data-card">
                     <h2>Gutter</h2>
-                    <div class="toolbar no-print">
+                    <div class="control-toolbar preset-selector-toolbar print-hidden">
                       <label>
-                        <span class="muted">Preset</span>
-                        <select id="gutterPresetSelect" class="preset-select">
+                        <span class="text-muted-detail">Preset</span>
+                        <select id="gutterPresetSelect" class="preset-selector-control">
                           <option value="">Choose a gutter preset…</option>
                         </select>
                       </label>
                     </div>
-                    <div class="row">
+                    <div class="input-field-row">
                       <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625" value="0.125"></label>
                       <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625" value="0.125"></label>
                     </div>
                   </div>
 
-                  <div class="card">
+                  <div class="data-card">
                     <h2>Docs (limit)</h2>
-                    <div class="row">
+                    <div class="input-field-row">
                       <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
                       <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
                     </div>
                   </div>
 
-                  <div class="card">
+                  <div class="data-card">
                     <h2>Margins (inside printable)</h2>
-                    <div class="row4">
+                    <div class="input-field-row-quad">
                       <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" value="" placeholder="auto"></label>
                       <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" value="" placeholder="auto"></label>
                       <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" value="" placeholder="auto"></label>
@@ -140,9 +140,9 @@
                     </div>
                   </div>
 
-                  <div class="card">
+                  <div class="data-card">
                     <h2>Non‑Printable Area</h2>
-                    <div class="row4">
+                    <div class="input-field-row-quad">
                       <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625" value="0.0625"></label>
                       <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625" value="0.0625"></label>
                       <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625" value="0.0625"></label>
@@ -151,184 +151,184 @@
                   </div>
                 </div>
 
-                <div class="toolbar no-print inputs-actions">
-                  <button class="btn primary" id="calcBtn">Update Preview</button>
-                  <button class="btn" id="resetBtn">Reset</button>
-                  <span class="k" id="status"></span>
+                <div class="control-toolbar input-action-toolbar print-hidden">
+                  <button class="action-button action-button-primary" id="calcBtn">Update Preview</button>
+                  <button class="action-button" id="resetBtn">Reset</button>
+                  <span class="text-metric-readout" id="status"></span>
                 </div>
               </div>
             </div>
           </section>
 
           <section id="tab-presets">
-            <div class="presets-pane">
-              <div class="card stack preset-intro">
+            <div class="layout-preset-pane">
+              <div class="data-card layout-stack layout-preset-introduction">
                 <h2>Preset Layouts</h2>
-                <p class="muted">
+                <p class="text-muted-detail">
                   Jump-start common production setups with one click. Each preset configures sheet, document, gutters, safety
                   areas, and finishing marks to match the listed specification.
                 </p>
               </div>
-              <div class="preset-grid grid">
-                <div class="card stack preset-card">
-                  <div class="preset-card-header">
+              <div class="layout-preset-grid layout-grid-group">
+                <div class="data-card layout-stack layout-preset-card">
+                  <div class="layout-preset-card-header">
                     <h3>Folded Business Card</h3>
-                    <p class="muted">12×18 sheet, 3.5×5 document, ⅛″ gutters, non-printable margin 1⁄16″.</p>
+                    <p class="text-muted-detail">12×18 sheet, 3.5×5 document, ⅛″ gutters, non-printable margin 1⁄16″.</p>
                   </div>
                   <ul>
                     <li>Auto margins enabled</li>
                     <li>Horizontal bifold score at 0.5</li>
                   </ul>
-                  <button class="btn primary" data-layout-preset="folded-business-card">Apply preset</button>
+                  <button class="action-button action-button-primary" data-layout-preset="folded-business-card">Apply preset</button>
                 </div>
-                <div class="card stack preset-card">
-                  <div class="preset-card-header">
+                <div class="data-card layout-stack layout-preset-card">
+                  <div class="layout-preset-card-header">
                     <h3>Tri-fold Brochure</h3>
-                    <p class="muted">12×18 sheet, 11×8.5 document, 0.25″ gutters, 0.125″ non-printable area.</p>
+                    <p class="text-muted-detail">12×18 sheet, 11×8.5 document, 0.25″ gutters, 0.125″ non-printable area.</p>
                   </div>
                   <ul>
                     <li>Vertical scores at ⅓ and ⅔</li>
                   </ul>
-                  <button class="btn primary" data-layout-preset="trifold-brochure">Apply preset</button>
+                  <button class="action-button action-button-primary" data-layout-preset="trifold-brochure">Apply preset</button>
                 </div>
-                <div class="card stack preset-card">
-                  <div class="preset-card-header">
+                <div class="data-card layout-stack layout-preset-card">
+                  <div class="layout-preset-card-header">
                     <h3>Postcard Gang Run</h3>
-                    <p class="muted">13×19 sheet, 4×6 document, ⅛″ gutters, 0.1″ non-printable area.</p>
+                    <p class="text-muted-detail">13×19 sheet, 4×6 document, ⅛″ gutters, 0.1″ non-printable area.</p>
                   </div>
                   <ul>
                     <li>No scores or perforations</li>
                   </ul>
-                  <button class="btn primary" data-layout-preset="postcard-gang-run">Apply preset</button>
+                  <button class="action-button action-button-primary" data-layout-preset="postcard-gang-run">Apply preset</button>
                 </div>
-                <div class="card stack preset-card">
-                  <div class="preset-card-header">
+                <div class="data-card layout-stack layout-preset-card">
+                  <div class="layout-preset-card-header">
                     <h3>Event Tickets</h3>
-                    <p class="muted">12×18 sheet, 2×5.5 document, 0.125″ H / 0.25″ V gutters, 1⁄16″ non-printable.</p>
+                    <p class="text-muted-detail">12×18 sheet, 2×5.5 document, 0.125″ H / 0.25″ V gutters, 1⁄16″ non-printable.</p>
                   </div>
                   <ul>
                     <li>Vertical perforation at 0.5</li>
                   </ul>
-                  <button class="btn primary" data-layout-preset="event-tickets">Apply preset</button>
+                  <button class="action-button action-button-primary" data-layout-preset="event-tickets">Apply preset</button>
                 </div>
-                <div class="card stack preset-card">
-                  <div class="preset-card-header">
+                <div class="data-card layout-stack layout-preset-card">
+                  <div class="layout-preset-card-header">
                     <h3>Table Tents</h3>
-                    <p class="muted">13×19 sheet, 5×7 document, 0.25″ gutters, 0.125″ non-printable area.</p>
+                    <p class="text-muted-detail">13×19 sheet, 5×7 document, 0.25″ gutters, 0.125″ non-printable area.</p>
                   </div>
                   <ul>
                     <li>Horizontal scores at 0.33 and 0.66</li>
                   </ul>
-                  <button class="btn primary" data-layout-preset="table-tents">Apply preset</button>
+                  <button class="action-button action-button-primary" data-layout-preset="table-tents">Apply preset</button>
                 </div>
               </div>
             </div>
           </section>
 
           <section id="tab-summary">
-            <div class="summary">
-              <div class="card"><h3>Counts</h3>
-                <div>Across: <span class="v" id="vAcross">—</span></div>
-                <div>Down: <span class="v" id="vDown">—</span></div>
-                <div>Total: <span class="v" id="vTotal">—</span></div>
+            <div class="summary-metrics-grid">
+              <div class="data-card"><h3>Counts</h3>
+                <div>Across: <span class="summary-metric-value" id="vAcross">—</span></div>
+                <div>Down: <span class="summary-metric-value" id="vDown">—</span></div>
+                <div>Total: <span class="summary-metric-value" id="vTotal">—</span></div>
               </div>
-              <div class="card"><h3>Layout Area</h3>
-                <div>W × H: <span class="v" id="vLayout">—</span></div>
-                <div>Origin: <span class="v" id="vOrigin">—</span></div>
-                <div>Realized Margins: <span class="v" id="vRealMargins">—</span></div>
+              <div class="data-card"><h3>Layout Area</h3>
+                <div>W × H: <span class="summary-metric-value" id="vLayout">—</span></div>
+                <div>Origin: <span class="summary-metric-value" id="vOrigin">—</span></div>
+                <div>Realized Margins: <span class="summary-metric-value" id="vRealMargins">—</span></div>
               </div>
-              <div class="card"><h3>Utilization</h3>
-                <div>Used W/H: <span class="v" id="vUsed">—</span></div>
-                <div>Trailing W/H: <span class="v" id="vTrail">—</span></div>
+              <div class="data-card"><h3>Utilization</h3>
+                <div>Used W/H: <span class="summary-metric-value" id="vUsed">—</span></div>
+                <div>Trailing W/H: <span class="summary-metric-value" id="vTrail">—</span></div>
               </div>
             </div>
           </section>
 
           <section id="tab-finishing">
-            <h3 style="margin-bottom:6px">Cut & Slit Systems</h3>
-            <div class="grid" style="grid-template-columns:1fr 1fr">
-              <div class="card"><h3>Cuts (Y edges)</h3>
-                <table class="table" id="tblCuts"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+            <h3 style="margin-bottom:6px">Cut &amp; Slit Systems</h3>
+            <div class="layout-grid-group" style="grid-template-columns:1fr 1fr">
+              <div class="data-card"><h3>Cuts (Y edges)</h3>
+                <table class="data-table" id="tblCuts"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
               </div>
-              <div class="card"><h3>Slits (X edges)</h3>
-                <table class="table" id="tblSlits"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+              <div class="data-card"><h3>Slits (X edges)</h3>
+                <table class="data-table" id="tblSlits"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
               </div>
             </div>
           </section>
 
           <section id="tab-scores">
-            <div class="scores-pane">
-              <div class="score-layout">
-                <div class="score-column">
-                  <div class="card stack score-card-intro">
-                    <div class="score-card-title">
+            <div class="finishing-score-pane">
+              <div class="finishing-score-layout">
+                <div class="finishing-score-column">
+                  <div class="data-card layout-stack finishing-score-card-intro">
+                    <div class="finishing-score-card-title">
                       <h3>Score Planning</h3>
-                      <p class="muted">Scores are normalized to each document. Use a preset for common folds or switch to custom entry to fine-tune the layout.</p>
+                      <p class="text-muted-detail">Scores are normalized to each document. Use a preset for common folds or switch to custom entry to fine-tune the layout.</p>
                     </div>
                   </div>
-                  <div class="card stack score-card score-card-vertical">
-                    <div class="score-card-header">
-                      <div class="score-card-title">
+                  <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
+                    <div class="finishing-score-card-header">
+                      <div class="finishing-score-card-title">
                         <h3>Vertical Scores</h3>
-                        <p class="muted">Set positions for lines that run top-to-bottom across the sheet relative to the document width.</p>
+                        <p class="text-muted-detail">Set positions for lines that run top-to-bottom across the sheet relative to the document width.</p>
                       </div>
-                      <div class="score-presets no-print" role="group" aria-label="Vertical score presets">
-                        <button class="btn" id="scorePresetBifold" type="button">Bifold</button>
-                        <button class="btn" id="scorePresetTrifold" type="button">Trifold</button>
-                        <button class="btn" id="scorePresetCustom" type="button">Custom</button>
+                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical score presets">
+                        <button class="action-button" id="scorePresetBifold" type="button">Bifold</button>
+                        <button class="action-button" id="scorePresetTrifold" type="button">Trifold</button>
+                        <button class="action-button" id="scorePresetCustom" type="button">Custom</button>
                       </div>
                     </div>
-                    <div class="score-field stack-sm">
-                      <label class="score-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
+                    <div class="finishing-score-field layout-stack-compact">
+                      <label class="finishing-score-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
                         <span>Vertical scores</span>
                         <input id="scoresV" type="text" value="" placeholder="e.g., 0.5" />
                       </label>
-                      <p class="muted score-hint">Values are relative to the document width.</p>
+                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
                     </div>
                   </div>
-                  <div class="card stack score-card score-card-horizontal">
-                    <div class="score-card-header">
-                      <div class="score-card-title">
+                  <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
+                    <div class="finishing-score-card-header">
+                      <div class="finishing-score-card-title">
                         <h3>Horizontal Scores</h3>
-                        <p class="muted">Set positions for lines that run left-to-right across the sheet relative to the document height.</p>
+                        <p class="text-muted-detail">Set positions for lines that run left-to-right across the sheet relative to the document height.</p>
                       </div>
-                      <div class="score-presets no-print" role="group" aria-label="Horizontal score presets">
-                        <button class="btn" id="scorePresetHBifold" type="button">Bifold</button>
-                        <button class="btn" id="scorePresetHTrifold" type="button">Trifold</button>
-                        <button class="btn" id="scorePresetHCustom" type="button">Custom</button>
+                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal score presets">
+                        <button class="action-button" id="scorePresetHBifold" type="button">Bifold</button>
+                        <button class="action-button" id="scorePresetHTrifold" type="button">Trifold</button>
+                        <button class="action-button" id="scorePresetHCustom" type="button">Custom</button>
                       </div>
                     </div>
-                    <div class="score-field stack-sm">
-                      <label class="score-label" for="scoresH" title="CSV, 0–1">
+                    <div class="finishing-score-field layout-stack-compact">
+                      <label class="finishing-score-label" for="scoresH" title="CSV, 0–1">
                         <span>Horizontal scores</span>
                         <input id="scoresH" type="text" value="" placeholder="e.g., 0.5" />
                       </label>
-                      <p class="muted score-hint">Values are relative to the document height.</p>
+                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
                     </div>
                   </div>
-                  <div class="card score-actions-card">
-                    <div class="score-actions toolbar no-print">
-                      <button class="btn" id="swapScoreOffsets" type="button">Swap vertical ↔ horizontal scores</button>
-                      <button class="btn primary" id="applyScores" type="button">Apply Scores</button>
-                      <span class="muted">Leave fields blank to omit scores.</span>
+                  <div class="data-card finishing-action-card">
+                    <div class="control-toolbar finishing-action-toolbar print-hidden">
+                      <button class="action-button" id="swapScoreOffsets" type="button">Swap vertical ↔ horizontal scores</button>
+                      <button class="action-button action-button-primary" id="applyScores" type="button">Apply Scores</button>
+                      <span class="text-muted-detail">Leave fields blank to omit scores.</span>
                     </div>
                   </div>
                 </div>
-                <div class="score-column score-results">
-                  <div class="score-results-grid">
-                    <div class="card stack score-table-card">
+                <div class="finishing-score-column finishing-score-results">
+                  <div class="finishing-score-results-grid">
+                    <div class="data-card layout-stack finishing-score-table-card">
                       <div>
                         <h3>Scores (Y)</h3>
-                        <p class="muted">Horizontal runs positioned along the sheet height.</p>
+                        <p class="text-muted-detail">Horizontal runs positioned along the sheet height.</p>
                       </div>
-                      <table class="table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                      <table class="data-table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
                     </div>
-                    <div class="card stack score-table-card">
+                    <div class="data-card layout-stack finishing-score-table-card">
                       <div>
                         <h3>Scores (X)</h3>
-                        <p class="muted">Vertical runs positioned along the sheet width.</p>
+                        <p class="text-muted-detail">Vertical runs positioned along the sheet width.</p>
                       </div>
-                      <table class="table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                      <table class="data-table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
                     </div>
                   </div>
                 </div>
@@ -337,77 +337,77 @@
           </section>
 
           <section id="tab-perforations">
-            <div class="scores-pane">
-              <div class="score-layout">
-                <div class="score-column">
-                  <div class="card stack score-card-intro">
-                    <div class="score-card-title">
+            <div class="finishing-score-pane">
+              <div class="finishing-score-layout">
+                <div class="finishing-score-column">
+                  <div class="data-card layout-stack finishing-score-card-intro">
+                    <div class="finishing-score-card-title">
                       <h3>Perforation Planning</h3>
-                      <p class="muted">Configure tear-off runs relative to each document before applying them to the layout.</p>
+                      <p class="text-muted-detail">Configure tear-off runs relative to each document before applying them to the layout.</p>
                     </div>
                   </div>
-                  <div class="card stack score-card score-card-vertical">
-                    <div class="score-card-header">
-                      <div class="score-card-title">
+                  <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
+                    <div class="finishing-score-card-header">
+                      <div class="finishing-score-card-title">
                         <h3>Vertical Perforations</h3>
-                        <p class="muted">Lines running top-to-bottom relative to the document width.</p>
+                        <p class="text-muted-detail">Lines running top-to-bottom relative to the document width.</p>
                       </div>
-                      <div class="score-presets no-print" role="group" aria-label="Vertical perforation presets">
-                        <button class="btn" id="perfPresetVBifold" type="button">Bifold</button>
-                        <button class="btn" id="perfPresetVTrifold" type="button">Trifold</button>
-                        <button class="btn" id="perfPresetVCustom" type="button">Custom</button>
+                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical perforation presets">
+                        <button class="action-button" id="perfPresetVBifold" type="button">Bifold</button>
+                        <button class="action-button" id="perfPresetVTrifold" type="button">Trifold</button>
+                        <button class="action-button" id="perfPresetVCustom" type="button">Custom</button>
                       </div>
                     </div>
-                    <div class="score-field stack-sm">
-                      <label class="score-label" for="perfV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
+                    <div class="finishing-score-field layout-stack-compact">
+                      <label class="finishing-score-label" for="perfV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
                         <span>Vertical perforations</span>
                         <input id="perfV" type="text" value="" placeholder="e.g., 0.5" />
                       </label>
-                      <p class="muted score-hint">Values are relative to the document width.</p>
+                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
                     </div>
                   </div>
-                  <div class="card stack score-card score-card-horizontal">
-                    <div class="score-card-header">
-                      <div class="score-card-title">
+                  <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
+                    <div class="finishing-score-card-header">
+                      <div class="finishing-score-card-title">
                         <h3>Horizontal Perforations</h3>
-                        <p class="muted">Lines running left-to-right relative to the document height.</p>
+                        <p class="text-muted-detail">Lines running left-to-right relative to the document height.</p>
                       </div>
-                      <div class="score-presets no-print" role="group" aria-label="Horizontal perforation presets">
-                        <button class="btn" id="perfPresetHBifold" type="button">Bifold</button>
-                        <button class="btn" id="perfPresetHTrifold" type="button">Trifold</button>
-                        <button class="btn" id="perfPresetHCustom" type="button">Custom</button>
+                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal perforation presets">
+                        <button class="action-button" id="perfPresetHBifold" type="button">Bifold</button>
+                        <button class="action-button" id="perfPresetHTrifold" type="button">Trifold</button>
+                        <button class="action-button" id="perfPresetHCustom" type="button">Custom</button>
                       </div>
                     </div>
-                    <div class="score-field stack-sm">
-                      <label class="score-label" for="perfH" title="CSV, 0–1">
+                    <div class="finishing-score-field layout-stack-compact">
+                      <label class="finishing-score-label" for="perfH" title="CSV, 0–1">
                         <span>Horizontal perforations</span>
                         <input id="perfH" type="text" value="" placeholder="e.g., 0.5" />
                       </label>
-                      <p class="muted score-hint">Values are relative to the document height.</p>
+                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
                     </div>
                   </div>
-                  <div class="card score-actions-card">
-                    <div class="score-actions toolbar no-print">
-                      <button class="btn primary" id="applyPerforations" type="button">Apply Perforations</button>
-                      <span class="muted">Leave fields blank to omit perforations.</span>
+                  <div class="data-card finishing-action-card">
+                    <div class="control-toolbar finishing-action-toolbar print-hidden">
+                      <button class="action-button action-button-primary" id="applyPerforations" type="button">Apply Perforations</button>
+                      <span class="text-muted-detail">Leave fields blank to omit perforations.</span>
                     </div>
                   </div>
                 </div>
-                <div class="score-column score-results">
-                  <div class="score-results-grid">
-                    <div class="card stack score-table-card">
+                <div class="finishing-score-column finishing-score-results">
+                  <div class="finishing-score-results-grid">
+                    <div class="data-card layout-stack finishing-score-table-card">
                       <div>
                         <h3>Perforations (Y)</h3>
-                        <p class="muted">Horizontal perforation runs positioned along the sheet height.</p>
+                        <p class="text-muted-detail">Horizontal perforation runs positioned along the sheet height.</p>
                       </div>
-                      <table class="table" id="tblPerforationsH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                      <table class="data-table" id="tblPerforationsH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
                     </div>
-                    <div class="card stack score-table-card">
+                    <div class="data-card layout-stack finishing-score-table-card">
                       <div>
                         <h3>Perforations (X)</h3>
-                        <p class="muted">Vertical perforation runs positioned along the sheet width.</p>
+                        <p class="text-muted-detail">Vertical perforation runs positioned along the sheet width.</p>
                       </div>
-                      <table class="table" id="tblPerforationsV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                      <table class="data-table" id="tblPerforationsV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
                     </div>
                   </div>
                 </div>
@@ -416,34 +416,34 @@
           </section>
 
           <section id="tab-warnings">
-            <div class="card stack">
+            <div class="data-card layout-stack">
               <h2>Warnings</h2>
-              <p class="muted">Production notes and layout warnings will appear here in a future update.</p>
-              <p class="muted">For now, use this space to track manual adjustments or finishing considerations that fall outside the
+              <p class="text-muted-detail">Production notes and layout warnings will appear here in a future update.</p>
+              <p class="text-muted-detail">For now, use this space to track manual adjustments or finishing considerations that fall outside the
                 presets.</p>
             </div>
           </section>
 
           <section id="tab-print">
-            <div class="row">
-              <div class="card">
+            <div class="layout-grid-group">
+              <div class="data-card">
                 <h3>Summary Snapshot</h3>
-                <p class="muted">Review the calculated layout details without opening a print dialog.</p>
-                <div class="summary">
-                  <div>Sheet: <span class="v" id="pSheet">—</span></div>
-                  <div>Doc: <span class="v" id="pDoc">—</span></div>
-                  <div>Counts: <span class="v" id="pCounts">—</span></div>
-                  <div>Gutter: <span class="v" id="pGutter">—</span></div>
-                  <div>Margins: <span class="v" id="pMargins">—</span></div>
+                <p class="text-muted-detail">Review the calculated layout details without opening a print dialog.</p>
+                <div class="summary-metrics-grid">
+                  <div>Sheet: <span class="summary-metric-value" id="pSheet">—</span></div>
+                  <div>Doc: <span class="summary-metric-value" id="pDoc">—</span></div>
+                  <div>Counts: <span class="summary-metric-value" id="pCounts">—</span></div>
+                  <div>Gutter: <span class="summary-metric-value" id="pGutter">—</span></div>
+                  <div>Margins: <span class="summary-metric-value" id="pMargins">—</span></div>
                 </div>
               </div>
-              <div class="card">
+              <div class="data-card">
                 <h3>What prints?</h3>
-                <p class="muted">Summary cards and finishing tables remain available for browser printing.</p>
-                <p class="muted">Use this tab as a quick reference for layout specs shared with production.</p>
+                <p class="text-muted-detail">Summary cards and finishing tables remain available for browser printing.</p>
+                <p class="text-muted-detail">Use this tab as a quick reference for layout specs shared with production.</p>
               </div>
             </div>
-            <div class="print-only" id="printTables"></div>
+            <div class="print-only-content" id="printTables"></div>
           </section>
         </div>
       </main>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -726,25 +726,25 @@ function drawSVG(layout, fin) {
 const DEFAULT_TAB_KEY = 'inputs';
 
 function activateTab(targetKey = DEFAULT_TAB_KEY) {
-  const requestedTab = $(`.tab[data-tab='${targetKey}']`);
+  const requestedTab = $(`.output-tab-trigger[data-tab='${targetKey}']`);
   const requestedPane = document.querySelector(`#tab-${targetKey}`);
-  const fallbackTab = $(`.tab[data-tab='${DEFAULT_TAB_KEY}']`);
+  const fallbackTab = $(`.output-tab-trigger[data-tab='${DEFAULT_TAB_KEY}']`);
   const fallbackPane = document.querySelector(`#tab-${DEFAULT_TAB_KEY}`);
   const tabToActivate = requestedTab ?? fallbackTab;
   const paneToActivate = requestedPane ?? fallbackPane;
   if (!tabToActivate || !paneToActivate) return;
-  $$('.tab').forEach((x) => x.classList.remove('active'));
-  $$('.tabpanes>section').forEach((s) => s.classList.remove('active'));
-  tabToActivate.classList.add('active');
-  paneToActivate.classList.add('active');
+  $$('.output-tab-trigger').forEach((x) => x.classList.remove('is-active'));
+  $$('.output-tabpanel-collection>section').forEach((s) => s.classList.remove('is-active'));
+  tabToActivate.classList.add('is-active');
+  paneToActivate.classList.add('is-active');
 }
 
-$$('.tab').forEach((t) => t.addEventListener('click', () => activateTab(t.dataset.tab)));
+$$('.output-tab-trigger').forEach((t) => t.addEventListener('click', () => activateTab(t.dataset.tab)));
 
-const initiallyActiveTab = document.querySelector('.tab.active');
+const initiallyActiveTab = document.querySelector('.output-tab-trigger.is-active');
 activateTab(initiallyActiveTab ? initiallyActiveTab.dataset.tab : DEFAULT_TAB_KEY);
 
-$$('.layer-toggle').forEach((input) => {
+$$('.layer-visibility-toggle-input').forEach((input) => {
   const layer = input.dataset.layer;
   if (!layer) return;
   const initial = layerVisibility[layer] ?? true;


### PR DESCRIPTION
## Summary
- rename HTML class hooks to descriptive, semantic names for the preview, tabs, and configuration panels
- document every CSS class with layout and behavior notes while aligning selectors with the new naming scheme
- update JavaScript selectors to match the renamed tab and layer toggle classes

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690c1d315dc083248b21541ccabee30e