### PR TITLE
Refactor tab activation into registry

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,5 +1,14 @@
 import { sheetPresets, documentPresets, gutterPresets } from './input-presets.js';
 import { DEFAULT_INPUTS } from './config/defaults.js';
+import { initializeTabRegistry, registerTab } from './tabs/registry.js';
+import inputsTab from './tabs/inputs.js';
+import summaryTab from './tabs/summary.js';
+import finishingTab from './tabs/finishing.js';
+import scoresTab from './tabs/scores.js';
+import perforationsTab from './tabs/perforations.js';
+import warningsTab from './tabs/warnings.js';
+import printTab from './tabs/print.js';
+import presetsTab from './tabs/presets.js';
 import {
   MM_PER_INCH,
   clampToZero,
@@ -609,26 +618,16 @@ function drawSVG(layout, fin) {
 // ------------------------------------------------------------
 // 4. Event bindings
 // ------------------------------------------------------------
-const DEFAULT_TAB_KEY = 'inputs';
+registerTab(inputsTab.key, inputsTab);
+registerTab(summaryTab.key, summaryTab);
+registerTab(finishingTab.key, finishingTab);
+registerTab(scoresTab.key, scoresTab);
+registerTab(perforationsTab.key, perforationsTab);
+registerTab(warningsTab.key, warningsTab);
+registerTab(printTab.key, printTab);
+registerTab(presetsTab.key, presetsTab);
 
-function activateTab(targetKey = DEFAULT_TAB_KEY) {
-  const requestedTab = $(`.output-tab-trigger[data-tab='${targetKey}']`);
-  const requestedPane = document.querySelector(`#tab-${targetKey}`);
-  const fallbackTab = $(`.output-tab-trigger[data-tab='${DEFAULT_TAB_KEY}']`);
-  const fallbackPane = document.querySelector(`#tab-${DEFAULT_TAB_KEY}`);
-  const tabToActivate = requestedTab ?? fallbackTab;
-  const paneToActivate = requestedPane ?? fallbackPane;
-  if (!tabToActivate || !paneToActivate) return;
-  $$('.output-tab-trigger').forEach((x) => x.classList.remove('is-active'));
-  $$('.output-tabpanel-collection>section').forEach((s) => s.classList.remove('is-active'));
-  tabToActivate.classList.add('is-active');
-  paneToActivate.classList.add('is-active');
-}
-
-$$('.output-tab-trigger').forEach((t) => t.addEventListener('click', () => activateTab(t.dataset.tab)));
-
-const initiallyActiveTab = document.querySelector('.output-tab-trigger.is-active');
-activateTab(initiallyActiveTab ? initiallyActiveTab.dataset.tab : DEFAULT_TAB_KEY);
+initializeTabRegistry();
 
 $$('.layer-visibility-toggle-input').forEach((input) => {
   const layer = input.dataset.layer;

--- a/public/js/tabs/finishing.js
+++ b/public/js/tabs/finishing.js
@@ -1,0 +1,5 @@
+const finishingTab = {
+  key: 'finishing',
+};
+
+export default finishingTab;

--- a/public/js/tabs/inputs.js
+++ b/public/js/tabs/inputs.js
@@ -1,0 +1,5 @@
+const inputsTab = {
+  key: 'inputs',
+};
+
+export default inputsTab;

--- a/public/js/tabs/perforations.js
+++ b/public/js/tabs/perforations.js
@@ -1,0 +1,5 @@
+const perforationsTab = {
+  key: 'perforations',
+};
+
+export default perforationsTab;

--- a/public/js/tabs/presets.js
+++ b/public/js/tabs/presets.js
@@ -1,0 +1,5 @@
+const presetsTab = {
+  key: 'presets',
+};
+
+export default presetsTab;

--- a/public/js/tabs/print.js
+++ b/public/js/tabs/print.js
@@ -1,0 +1,5 @@
+const printTab = {
+  key: 'print',
+};
+
+export default printTab;

--- a/public/js/tabs/registry.js
+++ b/public/js/tabs/registry.js
@@ -1,0 +1,97 @@
+const DEFAULT_TAB_KEY = 'inputs';
+
+const tabModules = new Map();
+let activeTabKey = null;
+let fallbackTabKey = DEFAULT_TAB_KEY;
+let isInitialized = false;
+
+const getTabTrigger = (key) =>
+  typeof document !== 'undefined'
+    ? document.querySelector(`.output-tab-trigger[data-tab='${key}']`)
+    : null;
+const getTabPanel = (key) => (typeof document !== 'undefined' ? document.querySelector(`#tab-${key}`) : null);
+
+const resolveTabElements = (preferredKey) => {
+  const attemptKey = preferredKey ?? fallbackTabKey;
+  const requestedTrigger = getTabTrigger(attemptKey);
+  const requestedPanel = getTabPanel(attemptKey);
+  if (requestedTrigger && requestedPanel) {
+    return { key: attemptKey, trigger: requestedTrigger, panel: requestedPanel };
+  }
+  const fallbackTrigger = getTabTrigger(fallbackTabKey);
+  const fallbackPanel = getTabPanel(fallbackTabKey);
+  if (fallbackTrigger && fallbackPanel) {
+    return { key: fallbackTabKey, trigger: fallbackTrigger, panel: fallbackPanel };
+  }
+  const firstTrigger = typeof document !== 'undefined' ? document.querySelector('.output-tab-trigger') : null;
+  if (firstTrigger) {
+    const firstKey = firstTrigger.dataset.tab;
+    const firstPanel = getTabPanel(firstKey);
+    if (firstPanel) {
+      return { key: firstKey, trigger: firstTrigger, panel: firstPanel };
+    }
+  }
+  return { key: null, trigger: null, panel: null };
+};
+
+export function registerTab(key, module) {
+  if (!key) return;
+  tabModules.set(key, module ?? {});
+  const registeredModule = tabModules.get(key);
+  if (registeredModule && typeof registeredModule.onRegister === 'function') {
+    registeredModule.onRegister({ key, activateTab });
+  }
+}
+
+export function activateTab(targetKey) {
+  const { key, trigger, panel } = resolveTabElements(targetKey);
+  if (!key || !trigger || !panel) return;
+
+  if (activeTabKey && activeTabKey !== key) {
+    const previous = tabModules.get(activeTabKey);
+    if (previous && typeof previous.onDeactivate === 'function') {
+      previous.onDeactivate({ previousKey: activeTabKey, nextKey: key });
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    document.querySelectorAll('.output-tab-trigger').forEach((el) => el.classList.remove('is-active'));
+    document.querySelectorAll('.output-tabpanel-collection>section').forEach((el) => el.classList.remove('is-active'));
+  }
+
+  trigger.classList.add('is-active');
+  panel.classList.add('is-active');
+
+  const module = tabModules.get(key);
+  if (module && typeof module.onActivate === 'function') {
+    module.onActivate({ key, trigger, panel });
+  }
+
+  activeTabKey = key;
+}
+
+export function initializeTabRegistry(options = {}) {
+  const { defaultTab } = options;
+  if (typeof defaultTab === 'string' && defaultTab.trim().length > 0) {
+    fallbackTabKey = defaultTab;
+  }
+
+  if (!isInitialized && typeof document !== 'undefined') {
+    document.querySelectorAll('.output-tab-trigger').forEach((trigger) => {
+      trigger.addEventListener('click', () => activateTab(trigger.dataset.tab));
+    });
+    isInitialized = true;
+  }
+
+  const initiallyActive = typeof document !== 'undefined'
+    ? document.querySelector('.output-tab-trigger.is-active')
+    : null;
+  const initialKey = initiallyActive?.dataset?.tab ?? fallbackTabKey;
+  activateTab(initialKey);
+}
+
+export function getActiveTabKey() {
+  return activeTabKey;
+}
+
+export { DEFAULT_TAB_KEY };

--- a/public/js/tabs/scores.js
+++ b/public/js/tabs/scores.js
@@ -1,0 +1,5 @@
+const scoresTab = {
+  key: 'scores',
+};
+
+export default scoresTab;

--- a/public/js/tabs/summary.js
+++ b/public/js/tabs/summary.js
@@ -1,0 +1,5 @@
+const summaryTab = {
+  key: 'summary',
+};
+
+export default summaryTab;

--- a/public/js/tabs/warnings.js
+++ b/public/js/tabs/warnings.js
@@ -1,0 +1,5 @@
+const warningsTab = {
+  key: 'warnings',
+};
+
+export default warningsTab;


### PR DESCRIPTION
## Summary
- add a dedicated tab registry module to own activation and initialization
- create tab module placeholders and register them from the application entry
- update the main entry to initialize the registry during startup

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690c26a27c7883249bb4f23640181de1