### PR TITLE
Refactor tab modules and encapsulate UI logic

### DIFF
--- a/public/js/tabs/finishing.js
+++ b/public/js/tabs/finishing.js
@@ -1,5 +1,19 @@
+let initialized = false;
+
+function init() {
+  if (initialized) return;
+  initialized = true;
+}
+
 const finishingTab = {
   key: 'finishing',
+  init,
+  onActivate() {
+    init();
+  },
+  onRegister() {
+    init();
+  },
 };
 
 export default finishingTab;

--- a/public/js/tabs/inputs.js
+++ b/public/js/tabs/inputs.js
@@ -1,5 +1,370 @@
+import { sheetPresets, documentPresets, gutterPresets } from '../input-presets.js';
+import { DEFAULT_INPUTS } from '../config/defaults.js';
+import { $ } from '../utils/dom.js';
+import { MM_PER_INCH, convertForUnits, describePresetValue } from '../utils/units.js';
+
+const marginInputSelectors = ['#mTop', '#mRight', '#mBottom', '#mLeft'];
+const numericInputSelectors = [
+  '#sheetW',
+  '#sheetH',
+  '#docW',
+  '#docH',
+  '#gutH',
+  '#gutV',
+  ...marginInputSelectors,
+  '#npTop',
+  '#npRight',
+  '#npBottom',
+  '#npLeft',
+];
+
+const UNIT_TO_SYSTEM = { in: 'imperial', mm: 'metric' };
+const UNIT_PRECISION = { in: 3, mm: 2 };
+const presetSelectionMemory = {
+  sheet: { imperial: '', metric: '' },
+  document: { imperial: '', metric: '' },
+  gutter: { imperial: '', metric: '' },
+};
+
+let initialized = false;
+let autoMarginMode = true;
+let currentUnitsSelection = DEFAULT_INPUTS.units;
+let storedContext = { update: () => {}, status: () => {} };
+let keydownHandlerAttached = false;
+
+const getStatus = () => storedContext.status ?? (() => {});
+const getUpdate = () => storedContext.update ?? (() => {});
+
+const trimTrailingZeros = (str) => {
+  if (!str.includes('.')) return str;
+  const stripped = str.replace(/(\.\d*?[1-9])0+$/, '$1').replace(/\.0+$/, '');
+  return stripped === '' ? '0' : stripped;
+};
+
+const formatUnitValue = (value, precision) => trimTrailingZeros(Number(value || 0).toFixed(precision));
+
+function setAutoMarginMode(enabled) {
+  autoMarginMode = Boolean(enabled);
+  marginInputSelectors.forEach((selector) => {
+    const el = $(selector);
+    if (!el) return;
+    if (autoMarginMode) {
+      el.dataset.auto = 'true';
+      el.value = '';
+    } else {
+      delete el.dataset.auto;
+    }
+  });
+}
+
+function getSystemForUnits(units) {
+  return UNIT_TO_SYSTEM[units] || 'imperial';
+}
+
+function filterPresetsBySystem(presets, system) {
+  return presets.filter((preset) => {
+    if (!Array.isArray(preset.systems) || preset.systems.length === 0) return true;
+    return preset.systems.includes(system);
+  });
+}
+
+function populatePresetSelect(selectEl, presets, system, memoryKey) {
+  if (!selectEl) return;
+  const placeholder =
+    selectEl.dataset.placeholder ||
+    selectEl.querySelector('option[value=""]')?.textContent ||
+    'Choose a preset…';
+  const filtered = filterPresetsBySystem(presets, system);
+  selectEl.innerHTML = '';
+  const placeholderOption = document.createElement('option');
+  placeholderOption.value = '';
+  placeholderOption.textContent = placeholder;
+  selectEl.appendChild(placeholderOption);
+  filtered.forEach((preset) => {
+    const option = document.createElement('option');
+    option.value = preset.id;
+    option.textContent = preset.label;
+    option.dataset.width = preset.width;
+    option.dataset.height = preset.height;
+    selectEl.appendChild(option);
+  });
+  selectEl.dataset.placeholder = placeholder;
+  const memory = presetSelectionMemory[memoryKey] || {};
+  const storedValue = memory[system];
+  if (storedValue && filtered.some((preset) => preset.id === storedValue)) {
+    selectEl.value = storedValue;
+  } else {
+    selectEl.value = '';
+  }
+}
+
+function handlePresetSelect(selectEl, memoryKey, applyPreset) {
+  if (!selectEl) return;
+  selectEl.addEventListener('change', (event) => {
+    const option = event.target.selectedOptions?.[0];
+    const units = $('#units').value;
+    const system = getSystemForUnits(units);
+    const memory = presetSelectionMemory[memoryKey];
+    if (memory) {
+      memory[system] = event.target.value || '';
+    }
+    if (!option || !option.value) return;
+    const width = Number(option.dataset.width);
+    const height = Number(option.dataset.height);
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return;
+    applyPreset(width, height);
+    getUpdate()();
+  });
+}
+
+function setSheetPreset(w, h) {
+  const units = $('#units').value;
+  const width = convertForUnits(w, units);
+  const height = convertForUnits(h, units);
+  $('#sheetW').value = width;
+  $('#sheetH').value = height;
+  getStatus()(`Sheet preset ${describePresetValue(w, units)}×${describePresetValue(h, units)} ${units}`);
+}
+
+function setDocumentPreset(w, h) {
+  const units = $('#units').value;
+  const width = convertForUnits(w, units);
+  const height = convertForUnits(h, units);
+  $('#docW').value = width;
+  $('#docH').value = height;
+  getStatus()(`Document preset ${describePresetValue(w, units)}×${describePresetValue(h, units)} ${units}`);
+}
+
+function setGutterPreset(horizontal, vertical) {
+  const units = $('#units').value;
+  const h = convertForUnits(horizontal, units);
+  const v = convertForUnits(vertical, units);
+  $('#gutH').value = h;
+  $('#gutV').value = v;
+  getStatus()(`Gutter preset ${describePresetValue(horizontal, units)}×${describePresetValue(vertical, units)} ${units}`);
+}
+
+function applyNumericInputAttributes(el, units) {
+  const targetUnits = units === 'mm' ? 'mm' : 'in';
+  const attributes = [
+    ['step', el.dataset.inchStep],
+    ['min', el.dataset.inchMin],
+    ['max', el.dataset.inchMax],
+  ];
+  attributes.forEach(([attr, baseValue]) => {
+    if (baseValue == null || baseValue === '') {
+      el.removeAttribute(attr);
+      return;
+    }
+    if (targetUnits === 'in') {
+      el.setAttribute(attr, baseValue);
+      return;
+    }
+    const numeric = Number(baseValue);
+    if (!Number.isFinite(numeric)) return;
+    el.setAttribute(attr, formatUnitValue(numeric * MM_PER_INCH, 4));
+  });
+}
+
+function applyNumericInputUnits(units) {
+  numericInputSelectors.forEach((selector) => {
+    const el = $(selector);
+    if (!el) return;
+    applyNumericInputAttributes(el, units);
+  });
+}
+
+function convertInputs(fromUnits, toUnits) {
+  if (!toUnits) return;
+  const precision = UNIT_PRECISION[toUnits] ?? 3;
+  if (fromUnits !== toUnits) {
+    const factor =
+      fromUnits === 'in' && toUnits === 'mm'
+        ? MM_PER_INCH
+        : fromUnits === 'mm' && toUnits === 'in'
+        ? 1 / MM_PER_INCH
+        : null;
+    if (factor) {
+      numericInputSelectors.forEach((selector) => {
+        const el = $(selector);
+        if (!el) return;
+        const raw = el.value;
+        if (raw === '' || raw == null) return;
+        const num = Number(raw);
+        if (!Number.isFinite(num)) return;
+        const converted = num * factor;
+        el.value = formatUnitValue(converted, precision);
+      });
+    }
+  }
+  applyNumericInputUnits(toUnits);
+}
+
+function applyDefaultInputs() {
+  const { units, sheet, document, gutter, nonPrintable } = DEFAULT_INPUTS;
+  const precision = UNIT_PRECISION[units] ?? 3;
+  const setValue = (selector, value) => {
+    const el = $(selector);
+    if (!el) return;
+    if (value == null || value === '') {
+      el.value = '';
+      return;
+    }
+    el.value = formatUnitValue(value, precision);
+  };
+
+  $('#units').value = units;
+  currentUnitsSelection = units;
+  setAutoMarginMode(true);
+
+  setValue('#sheetW', sheet.width);
+  setValue('#sheetH', sheet.height);
+  setValue('#docW', document.width);
+  setValue('#docH', document.height);
+  setValue('#gutH', gutter.horizontal);
+  setValue('#gutV', gutter.vertical);
+  setValue('#npTop', nonPrintable.top);
+  setValue('#npRight', nonPrintable.right);
+  setValue('#npBottom', nonPrintable.bottom);
+  setValue('#npLeft', nonPrintable.left);
+
+  ['#mTop', '#mRight', '#mBottom', '#mLeft', '#forceAcross', '#forceDown', '#scoresV', '#scoresH', '#perfV', '#perfH'].forEach(
+    (selector) => {
+      const el = $(selector);
+      if (!el) return;
+      el.value = '';
+    }
+  );
+
+  getStatus()('');
+  applyNumericInputUnits(units);
+}
+
+function refreshPresetDropdowns(system) {
+  populatePresetSelect($('#sheetPresetSelect'), sheetPresets, system, 'sheet');
+  populatePresetSelect($('#documentPresetSelect'), documentPresets, system, 'document');
+  populatePresetSelect($('#gutterPresetSelect'), gutterPresets, system, 'gutter');
+}
+
+function attachUnitChangeListener(unitsSelect) {
+  if (!unitsSelect) return;
+  unitsSelect.addEventListener('change', (e) => {
+    const nextUnits = e.target.value;
+    convertInputs(currentUnitsSelection, nextUnits);
+    currentUnitsSelection = nextUnits;
+    refreshPresetDropdowns(getSystemForUnits(nextUnits));
+    getStatus()('Units changed');
+    getUpdate()();
+  });
+}
+
+function attachMarginListeners() {
+  marginInputSelectors.forEach((selector) => {
+    const el = $(selector);
+    if (!el) return;
+    ['input', 'change'].forEach((evt) =>
+      el.addEventListener(evt, () => {
+        if (!autoMarginMode) return;
+        setAutoMarginMode(false);
+      })
+    );
+  });
+}
+
+function attachPresetDropdownHandlers() {
+  handlePresetSelect($('#sheetPresetSelect'), 'sheet', setSheetPreset);
+  handlePresetSelect($('#documentPresetSelect'), 'document', setDocumentPreset);
+  handlePresetSelect($('#gutterPresetSelect'), 'gutter', setGutterPreset);
+}
+
+function attachActionButtons() {
+  $('#calcBtn')?.addEventListener('click', () => getUpdate()());
+  $('#resetBtn')?.addEventListener('click', () => {
+    applyDefaultInputs();
+    refreshPresetDropdowns(getSystemForUnits(currentUnitsSelection));
+    getUpdate()();
+  });
+}
+
+function attachApplyButtons() {
+  $('#applyScores')?.addEventListener('click', () => getUpdate()());
+  $('#applyPerforations')?.addEventListener('click', () => getUpdate()());
+}
+
+function attachKeyboardShortcut() {
+  if (keydownHandlerAttached) return;
+  document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') getUpdate()();
+  });
+  keydownHandlerAttached = true;
+}
+
+function runUnitConversionRegression() {
+  const initialUnits = currentUnitsSelection;
+  const alternateUnits = initialUnits === 'in' ? 'mm' : 'in';
+  const snapshot = numericInputSelectors
+    .map((selector) => {
+      const el = $(selector);
+      if (!el) return null;
+      return { selector, value: el.value, step: el.getAttribute('step') };
+    })
+    .filter(Boolean);
+  convertInputs(initialUnits, alternateUnits);
+  convertInputs(alternateUnits, initialUnits);
+  const mismatches = snapshot.filter(({ selector, value, step }) => {
+    const el = $(selector);
+    if (!el) return false;
+    return el.value !== value || el.getAttribute('step') !== step;
+  });
+  console.assert(mismatches.length === 0, 'Unit toggles should preserve numeric values and steps');
+}
+
+function init(context = {}) {
+  if (initialized) return;
+  storedContext = { ...storedContext, ...context };
+  setAutoMarginMode(autoMarginMode);
+  attachMarginListeners();
+  attachUnitChangeListener($('#units'));
+  attachPresetDropdownHandlers();
+  attachActionButtons();
+  attachApplyButtons();
+  attachKeyboardShortcut();
+  applyDefaultInputs();
+  refreshPresetDropdowns(getSystemForUnits(currentUnitsSelection));
+  runUnitConversionRegression();
+  initialized = true;
+}
+
 const inputsTab = {
   key: 'inputs',
+  init,
+  onActivate() {
+    init(storedContext);
+  },
+  onRegister({ update, status }) {
+    storedContext = { update, status };
+    init(storedContext);
+  },
 };
+
+export function isAutoMarginModeEnabled() {
+  return autoMarginMode;
+}
+
+export function enableAutoMarginMode(enabled) {
+  setAutoMarginMode(enabled);
+}
+
+export function getCurrentUnitsSelection() {
+  return currentUnitsSelection;
+}
+
+export function setCurrentUnitsSelection(units) {
+  currentUnitsSelection = units;
+}
+
+export function getNumericInputSelectors() {
+  return [...numericInputSelectors];
+}
 
 export default inputsTab;

--- a/public/js/tabs/perforations.js
+++ b/public/js/tabs/perforations.js
@@ -1,5 +1,201 @@
+import { $ } from '../utils/dom.js';
+
+const PERFORATION_PRESETS = {
+  bifold: [0.5],
+  trifold: [1 / 3, 2 / 3],
+};
+
+let initialized = false;
+let storedContext = { update: () => {}, status: () => {} };
+let verticalPerforationInput = null;
+let horizontalPerforationInput = null;
+let verticalPerforationPresetButtons = {};
+let horizontalPerforationPresetButtons = {};
+
+const getUpdate = () => storedContext.update ?? (() => {});
+const getStatus = () => storedContext.status ?? (() => {});
+
+const formatOffsetValue = (value) => {
+  const fixed = Number(value || 0).toFixed(4);
+  const trimmed = fixed.replace(/0+$/, '').replace(/\.$/, '');
+  return trimmed === '' ? '0' : trimmed;
+};
+
+function setScorePresetState(buttons, activeKey) {
+  Object.entries(buttons).forEach(([key, btn]) => {
+    if (!btn) return;
+    const isActive = key === activeKey;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+function setVerticalPerforationOffsets(offsets = []) {
+  if (!verticalPerforationInput) return;
+  if (!Array.isArray(offsets) || offsets.length === 0) {
+    verticalPerforationInput.value = '';
+    return;
+  }
+  verticalPerforationInput.value = offsets.map(formatOffsetValue).join(', ');
+}
+
+function lockVerticalPerforationInput(lock, presetKey) {
+  if (!verticalPerforationInput) return;
+  if (lock) {
+    verticalPerforationInput.setAttribute('readonly', 'true');
+    verticalPerforationInput.classList.add('is-locked');
+    if (presetKey) verticalPerforationInput.dataset.preset = presetKey;
+  } else {
+    verticalPerforationInput.removeAttribute('readonly');
+    verticalPerforationInput.classList.remove('is-locked');
+    delete verticalPerforationInput.dataset.preset;
+  }
+}
+
+function setVerticalPerforationPresetState(key) {
+  setScorePresetState(verticalPerforationPresetButtons, key);
+}
+
+function setHorizontalPerforationOffsets(offsets = []) {
+  if (!horizontalPerforationInput) return;
+  if (!Array.isArray(offsets) || offsets.length === 0) {
+    horizontalPerforationInput.value = '';
+    return;
+  }
+  horizontalPerforationInput.value = offsets.map(formatOffsetValue).join(', ');
+}
+
+function lockHorizontalPerforationInput(lock, presetKey) {
+  if (!horizontalPerforationInput) return;
+  if (lock) {
+    horizontalPerforationInput.setAttribute('readonly', 'true');
+    horizontalPerforationInput.classList.add('is-locked');
+    if (presetKey) horizontalPerforationInput.dataset.preset = presetKey;
+  } else {
+    horizontalPerforationInput.removeAttribute('readonly');
+    horizontalPerforationInput.classList.remove('is-locked');
+    delete horizontalPerforationInput.dataset.preset;
+  }
+}
+
+function setHorizontalPerforationPresetState(key) {
+  setScorePresetState(horizontalPerforationPresetButtons, key);
+}
+
+function attachPresetButtonHandlers() {
+  verticalPerforationPresetButtons = {
+    bifold: $('#perfPresetVBifold'),
+    trifold: $('#perfPresetVTrifold'),
+    custom: $('#perfPresetVCustom'),
+  };
+  horizontalPerforationPresetButtons = {
+    bifold: $('#perfPresetHBifold'),
+    trifold: $('#perfPresetHTrifold'),
+    custom: $('#perfPresetHCustom'),
+  };
+
+  verticalPerforationPresetButtons.bifold?.addEventListener('click', () => {
+    setVerticalPerforationOffsets(PERFORATION_PRESETS.bifold);
+    lockVerticalPerforationInput(true, 'bifold');
+    setVerticalPerforationPresetState('bifold');
+    getUpdate()();
+    getStatus()('Vertical bifold perforation preset applied');
+  });
+
+  verticalPerforationPresetButtons.trifold?.addEventListener('click', () => {
+    setVerticalPerforationOffsets(PERFORATION_PRESETS.trifold);
+    lockVerticalPerforationInput(true, 'trifold');
+    setVerticalPerforationPresetState('trifold');
+    getUpdate()();
+    getStatus()('Vertical trifold perforation preset applied');
+  });
+
+  verticalPerforationPresetButtons.custom?.addEventListener('click', () => {
+    lockVerticalPerforationInput(false);
+    setVerticalPerforationPresetState('custom');
+    verticalPerforationInput?.focus();
+    getUpdate()();
+    getStatus()('Vertical custom perforation entry enabled');
+  });
+
+  horizontalPerforationPresetButtons.bifold?.addEventListener('click', () => {
+    setHorizontalPerforationOffsets(PERFORATION_PRESETS.bifold);
+    lockHorizontalPerforationInput(true, 'bifold');
+    setHorizontalPerforationPresetState('bifold');
+    getUpdate()();
+    getStatus()('Horizontal bifold perforation preset applied');
+  });
+
+  horizontalPerforationPresetButtons.trifold?.addEventListener('click', () => {
+    setHorizontalPerforationOffsets(PERFORATION_PRESETS.trifold);
+    lockHorizontalPerforationInput(true, 'trifold');
+    setHorizontalPerforationPresetState('trifold');
+    getUpdate()();
+    getStatus()('Horizontal trifold perforation preset applied');
+  });
+
+  horizontalPerforationPresetButtons.custom?.addEventListener('click', () => {
+    lockHorizontalPerforationInput(false);
+    setHorizontalPerforationPresetState('custom');
+    horizontalPerforationInput?.focus();
+    getUpdate()();
+    getStatus()('Horizontal custom perforation entry enabled');
+  });
+}
+
+function attachInputListeners() {
+  if (verticalPerforationInput) {
+    ['input', 'change'].forEach((evt) =>
+      verticalPerforationInput.addEventListener(evt, () => {
+        if (verticalPerforationInput.readOnly) return;
+        setVerticalPerforationPresetState('custom');
+      })
+    );
+  }
+  if (horizontalPerforationInput) {
+    ['input', 'change'].forEach((evt) =>
+      horizontalPerforationInput.addEventListener(evt, () => {
+        if (horizontalPerforationInput.readOnly) return;
+        setHorizontalPerforationPresetState('custom');
+      })
+    );
+  }
+}
+
+function init(context = {}) {
+  if (initialized) {
+    storedContext = { ...storedContext, ...context };
+    return;
+  }
+  storedContext = { ...storedContext, ...context };
+  verticalPerforationInput = $('#perfV');
+  horizontalPerforationInput = $('#perfH');
+
+  attachPresetButtonHandlers();
+  attachInputListeners();
+
+  setVerticalPerforationPresetState('custom');
+  setHorizontalPerforationPresetState('custom');
+  initialized = true;
+}
+
 const perforationsTab = {
   key: 'perforations',
+  init,
+  onActivate(context) {
+    init(context);
+  },
+  onRegister(context) {
+    init(context);
+  },
+  api: {
+    setVerticalPerforationOffsets,
+    setHorizontalPerforationOffsets,
+    lockVerticalPerforationInput,
+    lockHorizontalPerforationInput,
+    setVerticalPerforationPresetState,
+    setHorizontalPerforationPresetState,
+  },
 };
 
 export default perforationsTab;

--- a/public/js/tabs/presets.js
+++ b/public/js/tabs/presets.js
@@ -1,5 +1,112 @@
+import { $, $$ } from '../utils/dom.js';
+import { formatValueForUnits } from '../utils/units.js';
+
+const marginInputSelectors = ['#mTop', '#mRight', '#mBottom', '#mLeft'];
+
+let initialized = false;
+let storedContext = {
+  update: () => {},
+  status: () => {},
+  enableAutoMarginMode: () => {},
+  scoresApi: null,
+  perforationsApi: null,
+};
+
+const getStatus = () => storedContext.status ?? (() => {});
+const getUpdate = () => storedContext.update ?? (() => {});
+
+function clearMarginInputs() {
+  marginInputSelectors.forEach((selector) => {
+    const el = $(selector);
+    if (el) el.value = '';
+  });
+}
+
+function setValueForUnits(selector, value, units) {
+  const el = $(selector);
+  if (!el) return;
+  if (!Number.isFinite(Number(value))) {
+    el.value = '';
+    return;
+  }
+  el.value = formatValueForUnits(Number(value), units);
+}
+
+function applyLayoutPreset(presetKey) {
+  const presets = window.LAYOUT_PRESETS || {};
+  const preset = presets[presetKey];
+  if (!preset) {
+    getStatus()(`Unknown layout preset: ${presetKey}`);
+    return;
+  }
+
+  storedContext.enableAutoMarginMode?.(true);
+  clearMarginInputs();
+
+  const units = $('#units')?.value || 'in';
+  const sheet = preset.sheet || {};
+  const document = preset.document || {};
+  const gutter = preset.gutter || {};
+  const np = preset.nonPrintable || {};
+
+  setValueForUnits('#sheetW', sheet.width ?? 0, units);
+  setValueForUnits('#sheetH', sheet.height ?? 0, units);
+  setValueForUnits('#docW', document.width ?? 0, units);
+  setValueForUnits('#docH', document.height ?? 0, units);
+  setValueForUnits('#gutH', gutter.horizontal ?? 0, units);
+  setValueForUnits('#gutV', gutter.vertical ?? 0, units);
+  setValueForUnits('#npTop', np.top ?? 0, units);
+  setValueForUnits('#npRight', np.right ?? 0, units);
+  setValueForUnits('#npBottom', np.bottom ?? 0, units);
+  setValueForUnits('#npLeft', np.left ?? 0, units);
+
+  const scoresApi = storedContext.scoresApi || {};
+  scoresApi.lockVerticalScoreInput?.(false);
+  scoresApi.lockHorizontalScoreInput?.(false);
+  scoresApi.setVerticalPresetState?.('custom');
+  scoresApi.setHorizontalPresetState?.('custom');
+  scoresApi.setVerticalScoreOffsets?.(preset.scores?.vertical ?? []);
+  scoresApi.setHorizontalScoreOffsets?.(preset.scores?.horizontal ?? []);
+
+  const perforationsApi = storedContext.perforationsApi || {};
+  perforationsApi.lockVerticalPerforationInput?.(false);
+  perforationsApi.lockHorizontalPerforationInput?.(false);
+  perforationsApi.setVerticalPerforationPresetState?.('custom');
+  perforationsApi.setHorizontalPerforationPresetState?.('custom');
+  perforationsApi.setVerticalPerforationOffsets?.(preset.perforations?.vertical ?? []);
+  perforationsApi.setHorizontalPerforationOffsets?.(preset.perforations?.horizontal ?? []);
+
+  getUpdate()();
+  getStatus()(`${preset.label} preset applied`);
+}
+
+function attachPresetButtons() {
+  $$('[data-layout-preset]').forEach((btn) => {
+    const key = btn.dataset.layoutPreset;
+    if (!key) return;
+    btn.addEventListener('click', () => applyLayoutPreset(key));
+  });
+}
+
+function init(context = {}) {
+  if (initialized) {
+    storedContext = { ...storedContext, ...context };
+    return;
+  }
+  storedContext = { ...storedContext, ...context };
+  attachPresetButtons();
+  initialized = true;
+}
+
 const presetsTab = {
   key: 'presets',
+  init,
+  onActivate(context) {
+    init(context);
+  },
+  onRegister(context) {
+    init(context);
+  },
 };
 
 export default presetsTab;

--- a/public/js/tabs/print.js
+++ b/public/js/tabs/print.js
@@ -1,5 +1,19 @@
+let initialized = false;
+
+function init() {
+  if (initialized) return;
+  initialized = true;
+}
+
 const printTab = {
   key: 'print',
+  init,
+  onActivate() {
+    init();
+  },
+  onRegister() {
+    init();
+  },
 };
 
 export default printTab;

--- a/public/js/tabs/registry.js
+++ b/public/js/tabs/registry.js
@@ -34,12 +34,12 @@ const resolveTabElements = (preferredKey) => {
   return { key: null, trigger: null, panel: null };
 };
 
-export function registerTab(key, module) {
+export function registerTab(key, module, context = {}) {
   if (!key) return;
   tabModules.set(key, module ?? {});
   const registeredModule = tabModules.get(key);
   if (registeredModule && typeof registeredModule.onRegister === 'function') {
-    registeredModule.onRegister({ key, activateTab });
+    registeredModule.onRegister({ key, activateTab, ...context });
   }
 }
 

--- a/public/js/tabs/scores.js
+++ b/public/js/tabs/scores.js
@@ -1,5 +1,219 @@
+import { $, parseOffsets } from '../utils/dom.js';
+
+const SCORE_PRESETS = {
+  bifold: [0.5],
+  trifold: [1 / 3, 2 / 3],
+};
+
+let initialized = false;
+let storedContext = { update: () => {}, status: () => {} };
+let verticalScoreInput = null;
+let horizontalScoreInput = null;
+let verticalScorePresetButtons = {};
+let horizontalScorePresetButtons = {};
+
+const getUpdate = () => storedContext.update ?? (() => {});
+const getStatus = () => storedContext.status ?? (() => {});
+
+const formatOffsetValue = (value) => {
+  const fixed = Number(value || 0).toFixed(4);
+  const trimmed = fixed.replace(/0+$/, '').replace(/\.$/, '');
+  return trimmed === '' ? '0' : trimmed;
+};
+
+function setScorePresetState(buttons, activeKey) {
+  Object.entries(buttons).forEach(([key, btn]) => {
+    if (!btn) return;
+    const isActive = key === activeKey;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+function setVerticalScoreOffsets(offsets = []) {
+  if (!verticalScoreInput) return;
+  if (!Array.isArray(offsets) || offsets.length === 0) {
+    verticalScoreInput.value = '';
+    return;
+  }
+  verticalScoreInput.value = offsets.map(formatOffsetValue).join(', ');
+}
+
+function lockVerticalScoreInput(lock, presetKey) {
+  if (!verticalScoreInput) return;
+  if (lock) {
+    verticalScoreInput.setAttribute('readonly', 'true');
+    verticalScoreInput.classList.add('is-locked');
+    if (presetKey) verticalScoreInput.dataset.preset = presetKey;
+  } else {
+    verticalScoreInput.removeAttribute('readonly');
+    verticalScoreInput.classList.remove('is-locked');
+    delete verticalScoreInput.dataset.preset;
+  }
+}
+
+function setVerticalPresetState(key) {
+  setScorePresetState(verticalScorePresetButtons, key);
+}
+
+function setHorizontalScoreOffsets(offsets = []) {
+  if (!horizontalScoreInput) return;
+  if (!Array.isArray(offsets) || offsets.length === 0) {
+    horizontalScoreInput.value = '';
+    return;
+  }
+  horizontalScoreInput.value = offsets.map(formatOffsetValue).join(', ');
+}
+
+function lockHorizontalScoreInput(lock, presetKey) {
+  if (!horizontalScoreInput) return;
+  if (lock) {
+    horizontalScoreInput.setAttribute('readonly', 'true');
+    horizontalScoreInput.classList.add('is-locked');
+    if (presetKey) horizontalScoreInput.dataset.preset = presetKey;
+  } else {
+    horizontalScoreInput.removeAttribute('readonly');
+    horizontalScoreInput.classList.remove('is-locked');
+    delete horizontalScoreInput.dataset.preset;
+  }
+}
+
+function setHorizontalPresetState(key) {
+  setScorePresetState(horizontalScorePresetButtons, key);
+}
+
+function swapScoreOffsets() {
+  if (!verticalScoreInput || !horizontalScoreInput) return;
+  const verticalOffsets = parseOffsets(verticalScoreInput.value);
+  const horizontalOffsets = parseOffsets(horizontalScoreInput.value);
+
+  lockVerticalScoreInput(false);
+  lockHorizontalScoreInput(false);
+  setVerticalPresetState('custom');
+  setHorizontalPresetState('custom');
+
+  setVerticalScoreOffsets(horizontalOffsets);
+  setHorizontalScoreOffsets(verticalOffsets);
+
+  getUpdate()();
+  getStatus()('Swapped vertical and horizontal score offsets');
+}
+
+function attachPresetButtonHandlers() {
+  verticalScorePresetButtons = {
+    bifold: $('#scorePresetBifold'),
+    trifold: $('#scorePresetTrifold'),
+    custom: $('#scorePresetCustom'),
+  };
+  horizontalScorePresetButtons = {
+    bifold: $('#scorePresetHBifold'),
+    trifold: $('#scorePresetHTrifold'),
+    custom: $('#scorePresetHCustom'),
+  };
+
+  verticalScorePresetButtons.bifold?.addEventListener('click', () => {
+    setVerticalScoreOffsets(SCORE_PRESETS.bifold);
+    lockVerticalScoreInput(true, 'bifold');
+    setVerticalPresetState('bifold');
+    getUpdate()();
+    getStatus()('Vertical bifold score preset applied');
+  });
+
+  verticalScorePresetButtons.trifold?.addEventListener('click', () => {
+    setVerticalScoreOffsets(SCORE_PRESETS.trifold);
+    lockVerticalScoreInput(true, 'trifold');
+    setVerticalPresetState('trifold');
+    getUpdate()();
+    getStatus()('Vertical trifold score preset applied');
+  });
+
+  verticalScorePresetButtons.custom?.addEventListener('click', () => {
+    lockVerticalScoreInput(false);
+    setVerticalPresetState('custom');
+    verticalScoreInput?.focus();
+    getUpdate()();
+    getStatus()('Vertical custom score entry enabled');
+  });
+
+  horizontalScorePresetButtons.bifold?.addEventListener('click', () => {
+    setHorizontalScoreOffsets(SCORE_PRESETS.bifold);
+    lockHorizontalScoreInput(true, 'bifold');
+    setHorizontalPresetState('bifold');
+    getUpdate()();
+    getStatus()('Horizontal bifold score preset applied');
+  });
+
+  horizontalScorePresetButtons.trifold?.addEventListener('click', () => {
+    setHorizontalScoreOffsets(SCORE_PRESETS.trifold);
+    lockHorizontalScoreInput(true, 'trifold');
+    setHorizontalPresetState('trifold');
+    getUpdate()();
+    getStatus()('Horizontal trifold score preset applied');
+  });
+
+  horizontalScorePresetButtons.custom?.addEventListener('click', () => {
+    lockHorizontalScoreInput(false);
+    setHorizontalPresetState('custom');
+    horizontalScoreInput?.focus();
+    getUpdate()();
+    getStatus()('Horizontal custom score entry enabled');
+  });
+}
+
+function attachInputListeners() {
+  if (verticalScoreInput) {
+    ['input', 'change'].forEach((evt) =>
+      verticalScoreInput.addEventListener(evt, () => {
+        if (verticalScoreInput.readOnly) return;
+        setVerticalPresetState('custom');
+      })
+    );
+  }
+  if (horizontalScoreInput) {
+    ['input', 'change'].forEach((evt) =>
+      horizontalScoreInput.addEventListener(evt, () => {
+        if (horizontalScoreInput.readOnly) return;
+        setHorizontalPresetState('custom');
+      })
+    );
+  }
+}
+
+function init(context = {}) {
+  if (initialized) {
+    storedContext = { ...storedContext, ...context };
+    return;
+  }
+  storedContext = { ...storedContext, ...context };
+  verticalScoreInput = $('#scoresV');
+  horizontalScoreInput = $('#scoresH');
+
+  attachPresetButtonHandlers();
+  attachInputListeners();
+  $('#swapScoreOffsets')?.addEventListener('click', swapScoreOffsets);
+
+  setVerticalPresetState('custom');
+  setHorizontalPresetState('custom');
+  initialized = true;
+}
+
 const scoresTab = {
   key: 'scores',
+  init,
+  onActivate(context) {
+    init(context);
+  },
+  onRegister(context) {
+    init(context);
+  },
+  api: {
+    setVerticalScoreOffsets,
+    setHorizontalScoreOffsets,
+    lockVerticalScoreInput,
+    lockHorizontalScoreInput,
+    setVerticalPresetState,
+    setHorizontalPresetState,
+  },
 };
 
 export default scoresTab;

--- a/public/js/tabs/summary.js
+++ b/public/js/tabs/summary.js
@@ -1,5 +1,32 @@
+import { $$, getLayerVisibility, setLayerVisibility, applyLayerVisibility } from '../utils/dom.js';
+
+let initialized = false;
+
+function init() {
+  if (initialized) return;
+  $$('.layer-visibility-toggle-input').forEach((input) => {
+    const layer = input.dataset.layer;
+    if (!layer) return;
+    const initial = getLayerVisibility(layer);
+    input.checked = initial;
+    setLayerVisibility(layer, initial);
+    input.addEventListener('change', (e) => {
+      setLayerVisibility(layer, e.target.checked);
+    });
+  });
+  applyLayerVisibility();
+  initialized = true;
+}
+
 const summaryTab = {
   key: 'summary',
+  init,
+  onActivate() {
+    init();
+  },
+  onRegister() {
+    init();
+  },
 };
 
 export default summaryTab;

--- a/public/js/tabs/warnings.js
+++ b/public/js/tabs/warnings.js
@@ -1,5 +1,19 @@
+let initialized = false;
+
+function init() {
+  if (initialized) return;
+  initialized = true;
+}
+
 const warningsTab = {
   key: 'warnings',
+  init,
+  onActivate() {
+    init();
+  },
+  onRegister() {
+    init();
+  },
 };
 
 export default warningsTab;


### PR DESCRIPTION
## Summary
- move tab-specific presets, score/perforation controls, and unit handling into their respective modules with dedicated init routines
- update the application entry point to register modules with context and initialize them through the tab registry
- wire summary-layer toggles and add placeholder init hooks for remaining tabs to keep module responsibilities isolated

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_690c27b14df083248e637a5c9618f3b5