### PR TITLE
Hydrate tab panels from templates

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -57,395 +57,402 @@
         </nav>
 
         <div class="output-tabpanel-collection">
-          <section id="tab-inputs" class="is-active">
-            <div class="input-layout-panel">
-              <div class="input-panel-header">
-                <h2>Input Controls</h2>
-                <p class="text-muted-detail">Define the sheet, document, and safety settings to drive the preview.</p>
-              </div>
-
-              <div class="input-scroll-container">
-                <div class="control-toolbar input-unit-controls print-hidden">
-                  <span>Units:</span>
-                  <select id="units">
-                    <option value="in">inches</option>
-                    <option value="mm">millimeters</option>
-                  </select>
-                </div>
-
-                <div class="input-card-grid">
-                  <div class="data-card">
-                    <h2>Sheet</h2>
-                    <div class="control-toolbar preset-selector-toolbar print-hidden">
-                      <label>
-                        <span class="text-muted-detail">Preset</span>
-                        <select id="sheetPresetSelect" class="preset-selector-control">
-                          <option value="">Choose a sheet preset…</option>
-                        </select>
-                      </label>
-                    </div>
-                    <div class="input-field-row">
-                      <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25"></label>
-                      <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25"></label>
-                    </div>
-                  </div>
-
-                  <div class="data-card">
-                    <h2>Document</h2>
-                    <div class="control-toolbar preset-selector-toolbar print-hidden">
-                      <label>
-                        <span class="text-muted-detail">Preset</span>
-                        <select id="documentPresetSelect" class="preset-selector-control">
-                          <option value="">Choose a document preset…</option>
-                        </select>
-                      </label>
-                    </div>
-                    <div class="input-field-row">
-                      <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125"></label>
-                      <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125"></label>
-                    </div>
-                  </div>
-
-                  <div class="data-card">
-                    <h2>Gutter</h2>
-                    <div class="control-toolbar preset-selector-toolbar print-hidden">
-                      <label>
-                        <span class="text-muted-detail">Preset</span>
-                        <select id="gutterPresetSelect" class="preset-selector-control">
-                          <option value="">Choose a gutter preset…</option>
-                        </select>
-                      </label>
-                    </div>
-                    <div class="input-field-row">
-                      <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625"></label>
-                      <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625"></label>
-                    </div>
-                  </div>
-
-                  <div class="data-card">
-                    <h2>Docs (limit)</h2>
-                    <div class="input-field-row">
-                      <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
-                      <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
-                    </div>
-                  </div>
-
-                  <div class="data-card">
-                    <h2>Margins (inside printable)</h2>
-                    <div class="input-field-row-quad">
-                      <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-                      <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-                      <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-                      <label><span>Left</span><input id="mLeft" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-                    </div>
-                  </div>
-
-                  <div class="data-card">
-                    <h2>Non‑Printable Area</h2>
-                    <div class="input-field-row-quad">
-                      <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625"></label>
-                      <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625"></label>
-                      <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625"></label>
-                      <label><span>Left</span><input id="npLeft" type="number" step="0.625" data-inch-step="0.625"></label>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="control-toolbar input-action-toolbar print-hidden">
-                  <button class="action-button action-button-primary" id="calcBtn">Update Preview</button>
-                  <button class="action-button" id="resetBtn">Reset</button>
-                  <span class="text-metric-readout" id="status"></span>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="tab-presets">
-            <div class="layout-preset-pane">
-              <div class="data-card layout-stack layout-preset-introduction">
-                <h2>Preset Layouts</h2>
-                <p class="text-muted-detail">
-                  Jump-start common production setups with one click. Each preset configures sheet, document, gutters, safety
-                  areas, and finishing marks to match the listed specification.
-                </p>
-              </div>
-              <div class="layout-preset-grid layout-grid-group">
-                <div class="data-card layout-stack layout-preset-card">
-                  <div class="layout-preset-card-header">
-                    <h3>Folded Business Card</h3>
-                    <p class="text-muted-detail">12×18 sheet, 3.5×5 document, ⅛″ gutters, non-printable margin 1⁄16″.</p>
-                  </div>
-                  <ul>
-                    <li>Auto margins enabled</li>
-                    <li>Horizontal bifold score at 0.5</li>
-                  </ul>
-                  <button class="action-button action-button-primary" data-layout-preset="folded-business-card">Apply preset</button>
-                </div>
-                <div class="data-card layout-stack layout-preset-card">
-                  <div class="layout-preset-card-header">
-                    <h3>Tri-fold Brochure</h3>
-                    <p class="text-muted-detail">12×18 sheet, 11×8.5 document, 0.25″ gutters, 0.125″ non-printable area.</p>
-                  </div>
-                  <ul>
-                    <li>Vertical scores at ⅓ and ⅔</li>
-                  </ul>
-                  <button class="action-button action-button-primary" data-layout-preset="trifold-brochure">Apply preset</button>
-                </div>
-                <div class="data-card layout-stack layout-preset-card">
-                  <div class="layout-preset-card-header">
-                    <h3>Postcard Gang Run</h3>
-                    <p class="text-muted-detail">13×19 sheet, 4×6 document, ⅛″ gutters, 0.1″ non-printable area.</p>
-                  </div>
-                  <ul>
-                    <li>No scores or perforations</li>
-                  </ul>
-                  <button class="action-button action-button-primary" data-layout-preset="postcard-gang-run">Apply preset</button>
-                </div>
-                <div class="data-card layout-stack layout-preset-card">
-                  <div class="layout-preset-card-header">
-                    <h3>Event Tickets</h3>
-                    <p class="text-muted-detail">12×18 sheet, 2×5.5 document, 0.125″ H / 0.25″ V gutters, 1⁄16″ non-printable.</p>
-                  </div>
-                  <ul>
-                    <li>Vertical perforation at 0.5</li>
-                  </ul>
-                  <button class="action-button action-button-primary" data-layout-preset="event-tickets">Apply preset</button>
-                </div>
-                <div class="data-card layout-stack layout-preset-card">
-                  <div class="layout-preset-card-header">
-                    <h3>Table Tents</h3>
-                    <p class="text-muted-detail">13×19 sheet, 5×7 document, 0.25″ gutters, 0.125″ non-printable area.</p>
-                  </div>
-                  <ul>
-                    <li>Horizontal scores at 0.33 and 0.66</li>
-                  </ul>
-                  <button class="action-button action-button-primary" data-layout-preset="table-tents">Apply preset</button>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="tab-summary">
-            <div class="summary-metrics-grid">
-              <div class="data-card"><h3>Counts</h3>
-                <div>Across: <span class="summary-metric-value" id="vAcross">—</span></div>
-                <div>Down: <span class="summary-metric-value" id="vDown">—</span></div>
-                <div>Total: <span class="summary-metric-value" id="vTotal">—</span></div>
-              </div>
-              <div class="data-card"><h3>Layout Area</h3>
-                <div>W × H: <span class="summary-metric-value" id="vLayout">—</span></div>
-                <div>Origin: <span class="summary-metric-value" id="vOrigin">—</span></div>
-                <div>Realized Margins: <span class="summary-metric-value" id="vRealMargins">—</span></div>
-              </div>
-              <div class="data-card"><h3>Utilization</h3>
-                <div>Used W/H: <span class="summary-metric-value" id="vUsed">—</span></div>
-                <div>Trailing W/H: <span class="summary-metric-value" id="vTrail">—</span></div>
-              </div>
-            </div>
-          </section>
-
-          <section id="tab-finishing">
-            <h3 style="margin-bottom:6px">Cut &amp; Slit Systems</h3>
-            <div class="layout-grid-group" style="grid-template-columns:1fr 1fr">
-              <div class="data-card"><h3>Cuts (Y edges)</h3>
-                <table class="data-table" id="tblCuts"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-              </div>
-              <div class="data-card"><h3>Slits (X edges)</h3>
-                <table class="data-table" id="tblSlits"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-              </div>
-            </div>
-          </section>
-
-          <section id="tab-scores">
-            <div class="finishing-score-pane">
-              <div class="finishing-score-layout">
-                <div class="finishing-score-column">
-                  <div class="data-card layout-stack finishing-score-card-intro">
-                    <div class="finishing-score-card-title">
-                      <h3>Score Planning</h3>
-                      <p class="text-muted-detail">Scores are normalized to each document. Use a preset for common folds or switch to custom entry to fine-tune the layout.</p>
-                    </div>
-                  </div>
-                  <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
-                    <div class="finishing-score-card-header">
-                      <div class="finishing-score-card-title">
-                        <h3>Vertical Scores</h3>
-                        <p class="text-muted-detail">Set positions for lines that run top-to-bottom across the sheet relative to the document width.</p>
-                      </div>
-                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical score presets">
-                        <button class="action-button" id="scorePresetBifold" type="button">Bifold</button>
-                        <button class="action-button" id="scorePresetTrifold" type="button">Trifold</button>
-                        <button class="action-button" id="scorePresetCustom" type="button">Custom</button>
-                      </div>
-                    </div>
-                    <div class="finishing-score-field layout-stack-compact">
-                      <label class="finishing-score-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
-                        <span>Vertical scores</span>
-                        <input id="scoresV" type="text" placeholder="e.g., 0.5" />
-                      </label>
-                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
-                    </div>
-                  </div>
-                  <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
-                    <div class="finishing-score-card-header">
-                      <div class="finishing-score-card-title">
-                        <h3>Horizontal Scores</h3>
-                        <p class="text-muted-detail">Set positions for lines that run left-to-right across the sheet relative to the document height.</p>
-                      </div>
-                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal score presets">
-                        <button class="action-button" id="scorePresetHBifold" type="button">Bifold</button>
-                        <button class="action-button" id="scorePresetHTrifold" type="button">Trifold</button>
-                        <button class="action-button" id="scorePresetHCustom" type="button">Custom</button>
-                      </div>
-                    </div>
-                    <div class="finishing-score-field layout-stack-compact">
-                      <label class="finishing-score-label" for="scoresH" title="CSV, 0–1">
-                        <span>Horizontal scores</span>
-                        <input id="scoresH" type="text" placeholder="e.g., 0.5" />
-                      </label>
-                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
-                    </div>
-                  </div>
-                  <div class="data-card finishing-action-card">
-                    <div class="control-toolbar finishing-action-toolbar print-hidden">
-                      <button class="action-button" id="swapScoreOffsets" type="button">Swap vertical ↔ horizontal scores</button>
-                      <button class="action-button action-button-primary" id="applyScores" type="button">Apply Scores</button>
-                      <span class="text-muted-detail">Leave fields blank to omit scores.</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="finishing-score-column finishing-score-results">
-                  <div class="finishing-score-results-grid">
-                    <div class="data-card layout-stack finishing-score-table-card">
-                      <div>
-                        <h3>Scores (Y)</h3>
-                        <p class="text-muted-detail">Horizontal runs positioned along the sheet height.</p>
-                      </div>
-                      <table class="data-table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-                    </div>
-                    <div class="data-card layout-stack finishing-score-table-card">
-                      <div>
-                        <h3>Scores (X)</h3>
-                        <p class="text-muted-detail">Vertical runs positioned along the sheet width.</p>
-                      </div>
-                      <table class="data-table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="tab-perforations">
-            <div class="finishing-score-pane">
-              <div class="finishing-score-layout">
-                <div class="finishing-score-column">
-                  <div class="data-card layout-stack finishing-score-card-intro">
-                    <div class="finishing-score-card-title">
-                      <h3>Perforation Planning</h3>
-                      <p class="text-muted-detail">Configure tear-off runs relative to each document before applying them to the layout.</p>
-                    </div>
-                  </div>
-                  <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
-                    <div class="finishing-score-card-header">
-                      <div class="finishing-score-card-title">
-                        <h3>Vertical Perforations</h3>
-                        <p class="text-muted-detail">Lines running top-to-bottom relative to the document width.</p>
-                      </div>
-                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical perforation presets">
-                        <button class="action-button" id="perfPresetVBifold" type="button">Bifold</button>
-                        <button class="action-button" id="perfPresetVTrifold" type="button">Trifold</button>
-                        <button class="action-button" id="perfPresetVCustom" type="button">Custom</button>
-                      </div>
-                    </div>
-                    <div class="finishing-score-field layout-stack-compact">
-                      <label class="finishing-score-label" for="perfV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
-                        <span>Vertical perforations</span>
-                        <input id="perfV" type="text" placeholder="e.g., 0.5" />
-                      </label>
-                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
-                    </div>
-                  </div>
-                  <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
-                    <div class="finishing-score-card-header">
-                      <div class="finishing-score-card-title">
-                        <h3>Horizontal Perforations</h3>
-                        <p class="text-muted-detail">Lines running left-to-right relative to the document height.</p>
-                      </div>
-                      <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal perforation presets">
-                        <button class="action-button" id="perfPresetHBifold" type="button">Bifold</button>
-                        <button class="action-button" id="perfPresetHTrifold" type="button">Trifold</button>
-                        <button class="action-button" id="perfPresetHCustom" type="button">Custom</button>
-                      </div>
-                    </div>
-                    <div class="finishing-score-field layout-stack-compact">
-                      <label class="finishing-score-label" for="perfH" title="CSV, 0–1">
-                        <span>Horizontal perforations</span>
-                        <input id="perfH" type="text" placeholder="e.g., 0.5" />
-                      </label>
-                      <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
-                    </div>
-                  </div>
-                  <div class="data-card finishing-action-card">
-                    <div class="control-toolbar finishing-action-toolbar print-hidden">
-                      <button class="action-button action-button-primary" id="applyPerforations" type="button">Apply Perforations</button>
-                      <span class="text-muted-detail">Leave fields blank to omit perforations.</span>
-                    </div>
-                  </div>
-                </div>
-                <div class="finishing-score-column finishing-score-results">
-                  <div class="finishing-score-results-grid">
-                    <div class="data-card layout-stack finishing-score-table-card">
-                      <div>
-                        <h3>Perforations (Y)</h3>
-                        <p class="text-muted-detail">Horizontal perforation runs positioned along the sheet height.</p>
-                      </div>
-                      <table class="data-table" id="tblPerforationsH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-                    </div>
-                    <div class="data-card layout-stack finishing-score-table-card">
-                      <div>
-                        <h3>Perforations (X)</h3>
-                        <p class="text-muted-detail">Vertical perforation runs positioned along the sheet width.</p>
-                      </div>
-                      <table class="data-table" id="tblPerforationsV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="tab-warnings">
-            <div class="data-card layout-stack">
-              <h2>Warnings</h2>
-              <p class="text-muted-detail">Production notes and layout warnings will appear here in a future update.</p>
-              <p class="text-muted-detail">For now, use this space to track manual adjustments or finishing considerations that fall outside the
-                presets.</p>
-            </div>
-          </section>
-
-          <section id="tab-print">
-            <div class="layout-grid-group">
-              <div class="data-card">
-                <h3>Summary Snapshot</h3>
-                <p class="text-muted-detail">Review the calculated layout details without opening a print dialog.</p>
-                <div class="summary-metrics-grid">
-                  <div>Sheet: <span class="summary-metric-value" id="pSheet">—</span></div>
-                  <div>Doc: <span class="summary-metric-value" id="pDoc">—</span></div>
-                  <div>Counts: <span class="summary-metric-value" id="pCounts">—</span></div>
-                  <div>Gutter: <span class="summary-metric-value" id="pGutter">—</span></div>
-                  <div>Margins: <span class="summary-metric-value" id="pMargins">—</span></div>
-                </div>
-              </div>
-              <div class="data-card">
-                <h3>What prints?</h3>
-                <p class="text-muted-detail">Summary cards and finishing tables remain available for browser printing.</p>
-                <p class="text-muted-detail">Use this tab as a quick reference for layout specs shared with production.</p>
-              </div>
-            </div>
-            <div class="print-only-content" id="printTables"></div>
-          </section>
+          <section id="tab-inputs" class="is-active" data-tab-template="tab-inputs-template"></section>
+          <section id="tab-presets" data-tab-template="tab-presets-template"></section>
+          <section id="tab-summary" data-tab-template="tab-summary-template"></section>
+          <section id="tab-finishing" data-tab-template="tab-finishing-template"></section>
+          <section id="tab-scores" data-tab-template="tab-scores-template"></section>
+          <section id="tab-perforations" data-tab-template="tab-perforations-template"></section>
+          <section id="tab-warnings" data-tab-template="tab-warnings-template"></section>
+          <section id="tab-print" data-tab-template="tab-print-template"></section>
         </div>
+
+        <template id="tab-inputs-template">
+          <div class="input-layout-panel">
+            <div class="input-panel-header">
+              <h2>Input Controls</h2>
+              <p class="text-muted-detail">Define the sheet, document, and safety settings to drive the preview.</p>
+            </div>
+
+            <div class="input-scroll-container">
+              <div class="control-toolbar input-unit-controls print-hidden">
+                <span>Units:</span>
+                <select id="units">
+                  <option value="in">inches</option>
+                  <option value="mm">millimeters</option>
+                </select>
+              </div>
+
+              <div class="input-card-grid">
+                <div class="data-card">
+                  <h2>Sheet</h2>
+                  <div class="control-toolbar preset-selector-toolbar print-hidden">
+                    <label>
+                      <span class="text-muted-detail">Preset</span>
+                      <select id="sheetPresetSelect" class="preset-selector-control">
+                        <option value="">Choose a sheet preset…</option>
+                      </select>
+                    </label>
+                  </div>
+                  <div class="input-field-row">
+                    <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25"></label>
+                    <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25"></label>
+                  </div>
+                </div>
+
+                <div class="data-card">
+                  <h2>Document</h2>
+                  <div class="control-toolbar preset-selector-toolbar print-hidden">
+                    <label>
+                      <span class="text-muted-detail">Preset</span>
+                      <select id="documentPresetSelect" class="preset-selector-control">
+                        <option value="">Choose a document preset…</option>
+                      </select>
+                    </label>
+                  </div>
+                  <div class="input-field-row">
+                    <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125"></label>
+                    <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125"></label>
+                  </div>
+                </div>
+
+                <div class="data-card">
+                  <h2>Gutter</h2>
+                  <div class="control-toolbar preset-selector-toolbar print-hidden">
+                    <label>
+                      <span class="text-muted-detail">Preset</span>
+                      <select id="gutterPresetSelect" class="preset-selector-control">
+                        <option value="">Choose a gutter preset…</option>
+                      </select>
+                    </label>
+                  </div>
+                  <div class="input-field-row">
+                    <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625"></label>
+                    <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625"></label>
+                  </div>
+                </div>
+
+                <div class="data-card">
+                  <h2>Docs (limit)</h2>
+                  <div class="input-field-row">
+                    <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
+                    <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
+                  </div>
+                </div>
+
+                <div class="data-card">
+                  <h2>Margins (inside printable)</h2>
+                  <div class="input-field-row-quad">
+                    <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+                    <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+                    <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+                    <label><span>Left</span><input id="mLeft" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+                  </div>
+                </div>
+
+                <div class="data-card">
+                  <h2>Non‑Printable Area</h2>
+                  <div class="input-field-row-quad">
+                    <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625"></label>
+                    <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625"></label>
+                    <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625"></label>
+                    <label><span>Left</span><input id="npLeft" type="number" step="0.625" data-inch-step="0.625"></label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="control-toolbar input-action-toolbar print-hidden">
+                <button class="action-button action-button-primary" id="calcBtn">Update Preview</button>
+                <button class="action-button" id="resetBtn">Reset</button>
+                <span class="text-metric-readout" id="status"></span>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <template id="tab-presets-template">
+          <div class="layout-preset-pane">
+            <div class="data-card layout-stack layout-preset-introduction">
+              <h2>Preset Layouts</h2>
+              <p class="text-muted-detail">
+                Jump-start common production setups with one click. Each preset configures sheet, document, gutters, safety areas, and finishing marks to match the listed specification.
+              </p>
+            </div>
+            <div class="layout-preset-grid layout-grid-group">
+              <div class="data-card layout-stack layout-preset-card">
+                <div class="layout-preset-card-header">
+                  <h3>Folded Business Card</h3>
+                  <p class="text-muted-detail">12×18 sheet, 3.5×5 document, ⅛″ gutters, non-printable margin 1⁄16″.</p>
+                </div>
+                <ul>
+                  <li>Auto margins enabled</li>
+                  <li>Horizontal bifold score at 0.5</li>
+                </ul>
+                <button class="action-button action-button-primary" data-layout-preset="folded-business-card">Apply preset</button>
+              </div>
+              <div class="data-card layout-stack layout-preset-card">
+                <div class="layout-preset-card-header">
+                  <h3>Tri-fold Brochure</h3>
+                  <p class="text-muted-detail">12×18 sheet, 11×8.5 document, 0.25″ gutters, 0.125″ non-printable area.</p>
+                </div>
+                <ul>
+                  <li>Vertical scores at ⅓ and ⅔</li>
+                </ul>
+                <button class="action-button action-button-primary" data-layout-preset="trifold-brochure">Apply preset</button>
+              </div>
+              <div class="data-card layout-stack layout-preset-card">
+                <div class="layout-preset-card-header">
+                  <h3>Postcard Gang Run</h3>
+                  <p class="text-muted-detail">13×19 sheet, 4×6 document, ⅛″ gutters, 0.1″ non-printable area.</p>
+                </div>
+                <ul>
+                  <li>No scores or perforations</li>
+                </ul>
+                <button class="action-button action-button-primary" data-layout-preset="postcard-gang-run">Apply preset</button>
+              </div>
+              <div class="data-card layout-stack layout-preset-card">
+                <div class="layout-preset-card-header">
+                  <h3>Event Tickets</h3>
+                  <p class="text-muted-detail">12×18 sheet, 2×5.5 document, 0.125″ H / 0.25″ V gutters, 1⁄16″ non-printable.</p>
+                </div>
+                <ul>
+                  <li>Vertical perforation at 0.5</li>
+                </ul>
+                <button class="action-button action-button-primary" data-layout-preset="event-tickets">Apply preset</button>
+              </div>
+              <div class="data-card layout-stack layout-preset-card">
+                <div class="layout-preset-card-header">
+                  <h3>Table Tents</h3>
+                  <p class="text-muted-detail">13×19 sheet, 5×7 document, 0.25″ gutters, 0.125″ non-printable area.</p>
+                </div>
+                <ul>
+                  <li>Horizontal scores at 0.33 and 0.66</li>
+                </ul>
+                <button class="action-button action-button-primary" data-layout-preset="table-tents">Apply preset</button>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <template id="tab-summary-template">
+          <div class="summary-metrics-grid">
+            <div class="data-card"><h3>Counts</h3>
+              <div>Across: <span class="summary-metric-value" id="vAcross">—</span></div>
+              <div>Down: <span class="summary-metric-value" id="vDown">—</span></div>
+              <div>Total: <span class="summary-metric-value" id="vTotal">—</span></div>
+            </div>
+            <div class="data-card"><h3>Layout Area</h3>
+              <div>W × H: <span class="summary-metric-value" id="vLayout">—</span></div>
+              <div>Origin: <span class="summary-metric-value" id="vOrigin">—</span></div>
+              <div>Realized Margins: <span class="summary-metric-value" id="vRealMargins">—</span></div>
+            </div>
+            <div class="data-card"><h3>Utilization</h3>
+              <div>Used W/H: <span class="summary-metric-value" id="vUsed">—</span></div>
+              <div>Trailing W/H: <span class="summary-metric-value" id="vTrail">—</span></div>
+            </div>
+          </div>
+        </template>
+
+        <template id="tab-finishing-template">
+          <h3 style="margin-bottom:6px">Cut &amp; Slit Systems</h3>
+          <div class="layout-grid-group" style="grid-template-columns:1fr 1fr">
+            <div class="data-card"><h3>Cuts (Y edges)</h3>
+              <table class="data-table" id="tblCuts"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+            </div>
+            <div class="data-card"><h3>Slits (X edges)</h3>
+              <table class="data-table" id="tblSlits"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+            </div>
+          </div>
+        </template>
+
+        <template id="tab-scores-template">
+          <div class="finishing-score-pane">
+            <div class="finishing-score-layout">
+              <div class="finishing-score-column">
+                <div class="data-card layout-stack finishing-score-card-intro">
+                  <div class="finishing-score-card-title">
+                    <h3>Score Planning</h3>
+                    <p class="text-muted-detail">Scores are normalized to each document. Use a preset for common folds or switch to custom entry to fine-tune the layout.</p>
+                  </div>
+                </div>
+                <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
+                  <div class="finishing-score-card-header">
+                    <div class="finishing-score-card-title">
+                      <h3>Vertical Scores</h3>
+                      <p class="text-muted-detail">Set positions for lines that run top-to-bottom across the sheet relative to the document width.</p>
+                    </div>
+                    <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical score presets">
+                      <button class="action-button" id="scorePresetBifold" type="button">Bifold</button>
+                      <button class="action-button" id="scorePresetTrifold" type="button">Trifold</button>
+                      <button class="action-button" id="scorePresetCustom" type="button">Custom</button>
+                    </div>
+                  </div>
+                  <div class="finishing-score-field layout-stack-compact">
+                    <label class="finishing-score-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
+                      <span>Vertical scores</span>
+                      <input id="scoresV" type="text" placeholder="e.g., 0.5" />
+                    </label>
+                    <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
+                  </div>
+                </div>
+                <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
+                  <div class="finishing-score-card-header">
+                    <div class="finishing-score-card-title">
+                      <h3>Horizontal Scores</h3>
+                      <p class="text-muted-detail">Set positions for lines that run left-to-right across the sheet relative to the document height.</p>
+                    </div>
+                    <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal score presets">
+                      <button class="action-button" id="scorePresetHBifold" type="button">Bifold</button>
+                      <button class="action-button" id="scorePresetHTrifold" type="button">Trifold</button>
+                      <button class="action-button" id="scorePresetHCustom" type="button">Custom</button>
+                    </div>
+                  </div>
+                  <div class="finishing-score-field layout-stack-compact">
+                    <label class="finishing-score-label" for="scoresH" title="CSV, 0–1">
+                      <span>Horizontal scores</span>
+                      <input id="scoresH" type="text" placeholder="e.g., 0.5" />
+                    </label>
+                    <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
+                  </div>
+                </div>
+                <div class="data-card finishing-action-card">
+                  <div class="control-toolbar finishing-action-toolbar print-hidden">
+                    <button class="action-button" id="swapScoreOffsets" type="button">Swap vertical ↔ horizontal scores</button>
+                    <button class="action-button action-button-primary" id="applyScores" type="button">Apply Scores</button>
+                    <span class="text-muted-detail">Leave fields blank to omit scores.</span>
+                  </div>
+                </div>
+              </div>
+              <div class="finishing-score-column finishing-score-results">
+                <div class="finishing-score-results-grid">
+                  <div class="data-card layout-stack finishing-score-table-card">
+                    <div>
+                      <h3>Scores (Y)</h3>
+                      <p class="text-muted-detail">Horizontal runs positioned along the sheet height.</p>
+                    </div>
+                    <table class="data-table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                  </div>
+                  <div class="data-card layout-stack finishing-score-table-card">
+                    <div>
+                      <h3>Scores (X)</h3>
+                      <p class="text-muted-detail">Vertical runs positioned along the sheet width.</p>
+                    </div>
+                    <table class="data-table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <template id="tab-perforations-template">
+          <div class="finishing-score-pane">
+            <div class="finishing-score-layout">
+              <div class="finishing-score-column">
+                <div class="data-card layout-stack finishing-score-card-intro">
+                  <div class="finishing-score-card-title">
+                    <h3>Perforation Planning</h3>
+                    <p class="text-muted-detail">Configure tear-off runs relative to each document before applying them to the layout.</p>
+                  </div>
+                </div>
+                <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
+                  <div class="finishing-score-card-header">
+                    <div class="finishing-score-card-title">
+                      <h3>Vertical Perforations</h3>
+                      <p class="text-muted-detail">Lines running top-to-bottom relative to the document width.</p>
+                    </div>
+                    <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical perforation presets">
+                      <button class="action-button" id="perfPresetVBifold" type="button">Bifold</button>
+                      <button class="action-button" id="perfPresetVTrifold" type="button">Trifold</button>
+                      <button class="action-button" id="perfPresetVCustom" type="button">Custom</button>
+                    </div>
+                  </div>
+                  <div class="finishing-score-field layout-stack-compact">
+                    <label class="finishing-score-label" for="perfV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
+                      <span>Vertical perforations</span>
+                      <input id="perfV" type="text" placeholder="e.g., 0.5" />
+                    </label>
+                    <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
+                  </div>
+                </div>
+                <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
+                  <div class="finishing-score-card-header">
+                    <div class="finishing-score-card-title">
+                      <h3>Horizontal Perforations</h3>
+                      <p class="text-muted-detail">Lines running left-to-right relative to the document height.</p>
+                    </div>
+                    <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal perforation presets">
+                      <button class="action-button" id="perfPresetHBifold" type="button">Bifold</button>
+                      <button class="action-button" id="perfPresetHTrifold" type="button">Trifold</button>
+                      <button class="action-button" id="perfPresetHCustom" type="button">Custom</button>
+                    </div>
+                  </div>
+                  <div class="finishing-score-field layout-stack-compact">
+                    <label class="finishing-score-label" for="perfH" title="CSV, 0–1">
+                      <span>Horizontal perforations</span>
+                      <input id="perfH" type="text" placeholder="e.g., 0.5" />
+                    </label>
+                    <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
+                  </div>
+                </div>
+                <div class="data-card finishing-action-card">
+                  <div class="control-toolbar finishing-action-toolbar print-hidden">
+                    <button class="action-button action-button-primary" id="applyPerforations" type="button">Apply Perforations</button>
+                    <span class="text-muted-detail">Leave fields blank to omit perforations.</span>
+                  </div>
+                </div>
+              </div>
+              <div class="finishing-score-column finishing-score-results">
+                <div class="finishing-score-results-grid">
+                  <div class="data-card layout-stack finishing-score-table-card">
+                    <div>
+                      <h3>Perforations (Y)</h3>
+                      <p class="text-muted-detail">Horizontal perforation runs positioned along the sheet height.</p>
+                    </div>
+                    <table class="data-table" id="tblPerforationsH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                  </div>
+                  <div class="data-card layout-stack finishing-score-table-card">
+                    <div>
+                      <h3>Perforations (X)</h3>
+                      <p class="text-muted-detail">Vertical perforation runs positioned along the sheet width.</p>
+                    </div>
+                    <table class="data-table" id="tblPerforationsV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <template id="tab-warnings-template">
+          <div class="data-card layout-stack">
+            <h2>Warnings</h2>
+            <p class="text-muted-detail">Production notes and layout warnings will appear here in a future update.</p>
+            <p class="text-muted-detail">For now, use this space to track manual adjustments or finishing considerations that fall outside the presets.</p>
+          </div>
+        </template>
+
+        <template id="tab-print-template">
+          <div class="layout-grid-group">
+            <div class="data-card">
+              <h3>Summary Snapshot</h3>
+              <p class="text-muted-detail">Review the calculated layout details without opening a print dialog.</p>
+              <div class="summary-metrics-grid">
+                <div>Sheet: <span class="summary-metric-value" id="pSheet">—</span></div>
+                <div>Doc: <span class="summary-metric-value" id="pDoc">—</span></div>
+                <div>Counts: <span class="summary-metric-value" id="pCounts">—</span></div>
+                <div>Gutter: <span class="summary-metric-value" id="pGutter">—</span></div>
+                <div>Margins: <span class="summary-metric-value" id="pMargins">—</span></div>
+              </div>
+            </div>
+            <div class="data-card">
+              <h3>What prints?</h3>
+              <p class="text-muted-detail">Summary cards and finishing tables remain available for browser printing.</p>
+              <p class="text-muted-detail">Use this tab as a quick reference for layout specs shared with production.</p>
+            </div>
+          </div>
+          <div class="print-only-content" id="printTables"></div>
+        </template>
       </main>
     </div>
 

--- a/public/js/tabs/finishing.js
+++ b/public/js/tabs/finishing.js
@@ -1,6 +1,10 @@
+import { hydrateTabPanel } from './registry.js';
+
 let initialized = false;
+const TAB_KEY = 'finishing';
 
 function init() {
+  hydrateTabPanel(TAB_KEY);
   if (initialized) return;
   initialized = true;
 }

--- a/public/js/tabs/inputs.js
+++ b/public/js/tabs/inputs.js
@@ -2,7 +2,9 @@ import { sheetPresets, documentPresets, gutterPresets } from '../input-presets.j
 import { DEFAULT_INPUTS } from '../config/defaults.js';
 import { $ } from '../utils/dom.js';
 import { MM_PER_INCH, convertForUnits, describePresetValue } from '../utils/units.js';
+import { hydrateTabPanel } from './registry.js';
 
+const TAB_KEY = 'inputs';
 const marginInputSelectors = ['#mTop', '#mRight', '#mBottom', '#mLeft'];
 const numericInputSelectors = [
   '#sheetW',
@@ -320,8 +322,9 @@ function runUnitConversionRegression() {
 }
 
 function init(context = {}) {
-  if (initialized) return;
+  hydrateTabPanel(TAB_KEY);
   storedContext = { ...storedContext, ...context };
+  if (initialized) return;
   setAutoMarginMode(autoMarginMode);
   attachMarginListeners();
   attachUnitChangeListener($('#units'));

--- a/public/js/tabs/perforations.js
+++ b/public/js/tabs/perforations.js
@@ -1,4 +1,5 @@
 import { $ } from '../utils/dom.js';
+import { hydrateTabPanel } from './registry.js';
 
 const PERFORATION_PRESETS = {
   bifold: [0.5],
@@ -6,6 +7,7 @@ const PERFORATION_PRESETS = {
 };
 
 let initialized = false;
+const TAB_KEY = 'perforations';
 let storedContext = { update: () => {}, status: () => {} };
 let verticalPerforationInput = null;
 let horizontalPerforationInput = null;
@@ -163,11 +165,11 @@ function attachInputListeners() {
 }
 
 function init(context = {}) {
+  hydrateTabPanel(TAB_KEY);
+  storedContext = { ...storedContext, ...context };
   if (initialized) {
-    storedContext = { ...storedContext, ...context };
     return;
   }
-  storedContext = { ...storedContext, ...context };
   verticalPerforationInput = $('#perfV');
   horizontalPerforationInput = $('#perfH');
 

--- a/public/js/tabs/presets.js
+++ b/public/js/tabs/presets.js
@@ -1,6 +1,8 @@
 import { $, $$ } from '../utils/dom.js';
 import { formatValueForUnits } from '../utils/units.js';
+import { hydrateTabPanel } from './registry.js';
 
+const TAB_KEY = 'presets';
 const marginInputSelectors = ['#mTop', '#mRight', '#mBottom', '#mLeft'];
 
 let initialized = false;
@@ -89,11 +91,11 @@ function attachPresetButtons() {
 }
 
 function init(context = {}) {
+  hydrateTabPanel(TAB_KEY);
+  storedContext = { ...storedContext, ...context };
   if (initialized) {
-    storedContext = { ...storedContext, ...context };
     return;
   }
-  storedContext = { ...storedContext, ...context };
   attachPresetButtons();
   initialized = true;
 }

--- a/public/js/tabs/print.js
+++ b/public/js/tabs/print.js
@@ -1,6 +1,10 @@
+import { hydrateTabPanel } from './registry.js';
+
 let initialized = false;
+const TAB_KEY = 'print';
 
 function init() {
+  hydrateTabPanel(TAB_KEY);
   if (initialized) return;
   initialized = true;
 }

--- a/public/js/tabs/registry.js
+++ b/public/js/tabs/registry.js
@@ -10,6 +10,35 @@ const getTabTrigger = (key) =>
     ? document.querySelector(`.output-tab-trigger[data-tab='${key}']`)
     : null;
 const getTabPanel = (key) => (typeof document !== 'undefined' ? document.querySelector(`#tab-${key}`) : null);
+const hydratedPanels = new Set();
+
+const cloneTemplateIntoPanel = (panel) => {
+  if (!panel || typeof document === 'undefined') return panel;
+  if (panel.childElementCount > 0) return panel;
+  const templateId = panel.dataset?.tabTemplate;
+  if (!templateId) return panel;
+  const template = document.getElementById(templateId);
+  if (!template?.content) return panel;
+  const fragment = template.content.cloneNode(true);
+  panel.appendChild(fragment);
+  return panel;
+};
+
+export const getTabPanelTemplateId = (key) => getTabPanel(key)?.dataset?.tabTemplate ?? null;
+
+export function hydrateTabPanel(key) {
+  if (hydratedPanels.has(key)) {
+    return getTabPanel(key);
+  }
+  const panel = getTabPanel(key);
+  if (!panel) return null;
+  const hydratedPanel = cloneTemplateIntoPanel(panel);
+  hydratedPanels.add(key);
+  if (hydratedPanel) {
+    hydratedPanel.dataset.tabHydrated = 'true';
+  }
+  return hydratedPanel;
+}
 
 const resolveTabElements = (preferredKey) => {
   const attemptKey = preferredKey ?? fallbackTabKey;

--- a/public/js/tabs/scores.js
+++ b/public/js/tabs/scores.js
@@ -1,4 +1,5 @@
 import { $, parseOffsets } from '../utils/dom.js';
+import { hydrateTabPanel } from './registry.js';
 
 const SCORE_PRESETS = {
   bifold: [0.5],
@@ -6,6 +7,7 @@ const SCORE_PRESETS = {
 };
 
 let initialized = false;
+const TAB_KEY = 'scores';
 let storedContext = { update: () => {}, status: () => {} };
 let verticalScoreInput = null;
 let horizontalScoreInput = null;
@@ -180,11 +182,11 @@ function attachInputListeners() {
 }
 
 function init(context = {}) {
+  hydrateTabPanel(TAB_KEY);
+  storedContext = { ...storedContext, ...context };
   if (initialized) {
-    storedContext = { ...storedContext, ...context };
     return;
   }
-  storedContext = { ...storedContext, ...context };
   verticalScoreInput = $('#scoresV');
   horizontalScoreInput = $('#scoresH');
 

--- a/public/js/tabs/summary.js
+++ b/public/js/tabs/summary.js
@@ -1,8 +1,11 @@
 import { $$, getLayerVisibility, setLayerVisibility, applyLayerVisibility } from '../utils/dom.js';
+import { hydrateTabPanel } from './registry.js';
 
 let initialized = false;
+const TAB_KEY = 'summary';
 
 function init() {
+  hydrateTabPanel(TAB_KEY);
   if (initialized) return;
   $$('.layer-visibility-toggle-input').forEach((input) => {
     const layer = input.dataset.layer;

--- a/public/js/tabs/warnings.js
+++ b/public/js/tabs/warnings.js
@@ -1,6 +1,10 @@
+import { hydrateTabPanel } from './registry.js';
+
 let initialized = false;
+const TAB_KEY = 'warnings';
 
 function init() {
+  hydrateTabPanel(TAB_KEY);
   if (initialized) return;
   initialized = true;
 }


### PR DESCRIPTION
## Summary
- move each tab panel's markup into HTML templates referenced by data attributes
- add a registry helper that hydrates tab sections from their templates on demand
- ensure every tab module clones its template during initialization before binding listeners

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_690c2b2d41188324b032aa272c7cd195