### PR TITLE
Extract layout sections into reusable HTML fragments

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,67 +11,15 @@
   </head>
   <body>
     <div class="layout-app-shell">
-      <header class="layout-app-header">
-        <h1>Kevin’s Bitchin’ Print Calculator</h1>
-        <p class="text-muted-detail">Dial in your sheet specs, finishing steps, and print-ready outputs from one bitchin’ workspace.</p>
-      </header>
+      <!-- Fragment placeholder: App header -->
+      <div data-fragment="app-header"></div>
 
-      <section class="content-section sheet-preview-visualizer">
-        <div class="sheet-preview-container">
-          <div class="visualizer-visibility-toggles layer-visibility-toolbar print-hidden">
-            <label>
-              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="layout" checked />
-              <span>Layout Area</span>
-            </label>
-            <label>
-              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="docs" checked />
-              <span>Documents</span>
-            </label>
-            <label>
-              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="nonPrintable" checked />
-              <span>Non-Printable Area</span>
-            </label>
-            <label>
-              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="cuts" checked />
-              <span>Cuts</span>
-            </label>
-            <label>
-              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="slits" checked />
-              <span>Slits</span>
-            </label>
-            <label>
-              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="scores" checked />
-              <span>Scores</span>
-            </label>
-            <label>
-              <input class="layer-visibility-toggle-input" type="checkbox" data-layer="perforations" checked />
-              <span>Perforations</span>
-            </label>
-          </div>
-          <div class="sheet-preview-stage"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
-          <div class="sheet-preview-legend print-hidden">
-            <span><i class="legend-color-swatch legend-swatch-layout-area"></i>Layout Area</span>
-            <span><i class="legend-color-swatch legend-swatch-documents"></i>Documents</span>
-            <span><i class="legend-color-swatch legend-swatch-non-printable"></i>Non-Printable Area</span>
-            <span><i class="legend-color-swatch legend-swatch-cuts"></i>Cuts</span>
-            <span><i class="legend-color-swatch legend-swatch-slits"></i>Slits</span>
-            <span><i class="legend-color-swatch legend-swatch-scores"></i>Scores</span>
-            <span><i class="legend-color-swatch legend-swatch-perforations"></i>Perforations</span>
-          </div>
-        </div>
-      </section>
+      <!-- Fragment placeholder: Sheet preview visualizer -->
+      <div data-fragment="visualizer"></div>
 
       <main class="content-section output-details-section">
-        <nav class="output-tab-navigation-bar output-tab-navigation print-hidden">
-          <div class="output-tab-trigger is-active" data-tab="inputs">Inputs</div>
-          <div class="output-tab-trigger" data-tab="summary">Summary</div>
-          <div class="output-tab-trigger" data-tab="finishing">Cuts / Slits</div>
-          <div class="output-tab-trigger" data-tab="scores">Scores</div>
-          <div class="output-tab-trigger" data-tab="perforations">Perforations</div>
-          <div class="output-tab-trigger" data-tab="warnings">Warnings</div>
-          <div class="output-tab-trigger" data-tab="print">Print</div>
-          <div class="output-tab-trigger" data-tab="presets">Presets</div>
-        </nav>
+        <!-- Fragment placeholder: Output tab navigation -->
+        <div data-fragment="tab-nav"></div>
 
         <div class="output-tabpanel-collection">
           <section id="tab-inputs" class="is-active" data-tab-template="tab-inputs-template"></section>
@@ -473,6 +421,6 @@
       </main>
     </div>
 
-    <script type="module" src="./js/app.js"></script>
+    <script type="module" src="./js/bootstrap.js"></script>
   </body>
 </html>

--- a/docs/js/bootstrap.js
+++ b/docs/js/bootstrap.js
@@ -1,0 +1,10 @@
+import { loadFragments } from './utils/fragment-loader.js';
+
+async function bootstrap() {
+  await loadFragments(['app-header', 'visualizer', 'tab-nav']);
+  await import('./app.js');
+}
+
+bootstrap().catch((error) => {
+  console.error('Failed to bootstrap application shell:', error);
+});

--- a/docs/js/utils/fragment-loader.js
+++ b/docs/js/utils/fragment-loader.js
@@ -1,0 +1,30 @@
+const fragmentUrl = (name) => new URL(`../partials/fragments/${name}.html`, import.meta.url);
+
+async function fetchFragmentMarkup(name) {
+  const response = await fetch(fragmentUrl(name));
+  if (!response.ok) {
+    throw new Error(`Failed to fetch fragment "${name}" (${response.status})`);
+  }
+  return response.text();
+}
+
+async function injectFragment(name) {
+  if (typeof document === 'undefined') return null;
+  const placeholder = document.querySelector(`[data-fragment='${name}']`);
+  if (!placeholder) return null;
+
+  try {
+    const html = await fetchFragmentMarkup(name);
+    placeholder.insertAdjacentHTML('beforebegin', html);
+    placeholder.remove();
+    return name;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+export async function loadFragments(names = []) {
+  const tasks = names.map((name) => injectFragment(name));
+  await Promise.all(tasks);
+}

--- a/docs/partials/fragments/app-header.html
+++ b/docs/partials/fragments/app-header.html
@@ -1,0 +1,10 @@
+<!--
+  Fragment: App Header
+  Role: Provides the primary title block and introductory copy for the calculator UI shell.
+  Requires: Shared layout styles from css/style.css (layout-app-shell, layout-app-header).
+  Expected container: Replace the header slot within .layout-app-shell.
+-->
+<header class="layout-app-header">
+  <h1>Kevin’s Bitchin’ Print Calculator</h1>
+  <p class="text-muted-detail">Dial in your sheet specs, finishing steps, and print-ready outputs from one bitchin’ workspace.</p>
+</header>

--- a/docs/partials/fragments/tab-nav.html
+++ b/docs/partials/fragments/tab-nav.html
@@ -1,0 +1,16 @@
+<!--
+  Fragment: Output Tab Navigation
+  Role: Renders the tab trigger bar used to switch between calculator panels in the output details section.
+  Requires: Tab styling from css/tabs/base.css and behavior from js/tabs/registry.js along with js/app.js initialization.
+  Expected container: Replace the <nav> block at the top of .output-details-section.
+-->
+<nav class="output-tab-navigation-bar output-tab-navigation print-hidden">
+  <div class="output-tab-trigger is-active" data-tab="inputs">Inputs</div>
+  <div class="output-tab-trigger" data-tab="summary">Summary</div>
+  <div class="output-tab-trigger" data-tab="finishing">Cuts / Slits</div>
+  <div class="output-tab-trigger" data-tab="scores">Scores</div>
+  <div class="output-tab-trigger" data-tab="perforations">Perforations</div>
+  <div class="output-tab-trigger" data-tab="warnings">Warnings</div>
+  <div class="output-tab-trigger" data-tab="print">Print</div>
+  <div class="output-tab-trigger" data-tab="presets">Presets</div>
+</nav>

--- a/docs/partials/fragments/visualizer.html
+++ b/docs/partials/fragments/visualizer.html
@@ -1,0 +1,50 @@
+<!--
+  Fragment: Sheet Preview Visualizer
+  Role: Contains the live SVG preview, layer visibility toggles, and legend for the sheet layout visualization.
+  Requires: Layout and preview styles from css/style.css and tabs/base.css plus dynamic rendering from js/app.js.
+  Expected container: Replace the <section> reserved for .sheet-preview-visualizer within .layout-app-shell.
+-->
+<section class="content-section sheet-preview-visualizer">
+  <div class="sheet-preview-container">
+    <div class="visualizer-visibility-toggles layer-visibility-toolbar print-hidden">
+      <label>
+        <input class="layer-visibility-toggle-input" type="checkbox" data-layer="layout" checked />
+        <span>Layout Area</span>
+      </label>
+      <label>
+        <input class="layer-visibility-toggle-input" type="checkbox" data-layer="docs" checked />
+        <span>Documents</span>
+      </label>
+      <label>
+        <input class="layer-visibility-toggle-input" type="checkbox" data-layer="nonPrintable" checked />
+        <span>Non-Printable Area</span>
+      </label>
+      <label>
+        <input class="layer-visibility-toggle-input" type="checkbox" data-layer="cuts" checked />
+        <span>Cuts</span>
+      </label>
+      <label>
+        <input class="layer-visibility-toggle-input" type="checkbox" data-layer="slits" checked />
+        <span>Slits</span>
+      </label>
+      <label>
+        <input class="layer-visibility-toggle-input" type="checkbox" data-layer="scores" checked />
+        <span>Scores</span>
+      </label>
+      <label>
+        <input class="layer-visibility-toggle-input" type="checkbox" data-layer="perforations" checked />
+        <span>Perforations</span>
+      </label>
+    </div>
+    <div class="sheet-preview-stage"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
+    <div class="sheet-preview-legend print-hidden">
+      <span><i class="legend-color-swatch legend-swatch-layout-area"></i>Layout Area</span>
+      <span><i class="legend-color-swatch legend-swatch-documents"></i>Documents</span>
+      <span><i class="legend-color-swatch legend-swatch-non-printable"></i>Non-Printable Area</span>
+      <span><i class="legend-color-swatch legend-swatch-cuts"></i>Cuts</span>
+      <span><i class="legend-color-swatch legend-swatch-slits"></i>Slits</span>
+      <span><i class="legend-color-swatch legend-swatch-scores"></i>Scores</span>
+      <span><i class="legend-color-swatch legend-swatch-perforations"></i>Perforations</span>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add partial fragments for the app header, sheet preview visualizer, and output tab navigation with descriptive documentation
- load the new fragments at runtime via a fragment loader and bootstrap module before initializing the existing app code
- replace the inline markup in `index.html` with fragment placeholders and update the entry script

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_690c421387508324b215593661935ea8