### PR TITLE
Lazy load calculator UI partials at runtime

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,14 +12,14 @@
   <body>
     <div class="layout-app-shell">
       <!-- Fragment placeholder: App header -->
-      <div data-fragment="app-header"></div>
+      <div data-partial="app-header"></div>
 
       <!-- Fragment placeholder: Sheet preview visualizer -->
-      <div data-fragment="visualizer"></div>
+      <div data-partial="visualizer"></div>
 
       <main class="content-section output-details-section">
         <!-- Fragment placeholder: Output tab navigation -->
-        <div data-fragment="tab-nav"></div>
+        <div data-partial="tab-nav"></div>
 
         <div class="output-tabpanel-collection">
           <section id="tab-inputs" class="is-active" data-tab-template="tab-inputs-template"></section>
@@ -35,6 +35,8 @@
         <!-- Tab panel templates are loaded at runtime from docs/partials/templates via template-loader.js. -->
       </main>
     </div>
+
+    <div data-template-host hidden></div>
 
     <script type="module" src="./js/bootstrap.js"></script>
   </body>

--- a/docs/js/bootstrap.js
+++ b/docs/js/bootstrap.js
@@ -1,18 +1,26 @@
 import { loadFragments } from './utils/fragment-loader.js';
 import { loadTemplates } from './utils/template-loader.js';
 
+const collectFragmentPlaceholders = () => {
+  if (typeof document === 'undefined') return [];
+  const placeholders = document.querySelectorAll('[data-partial], [data-fragment]');
+  const names = Array.from(placeholders, (el) => el.dataset.partial || el.dataset.fragment).filter(Boolean);
+  return Array.from(new Set(names));
+};
+
+const collectTemplatePlaceholders = () => {
+  if (typeof document === 'undefined') return [];
+  const placeholders = document.querySelectorAll('[data-tab-template]');
+  const names = Array.from(placeholders, (el) => el.dataset.tabTemplate).filter(Boolean);
+  return Array.from(new Set(names));
+};
+
 async function bootstrap() {
-  await loadFragments(['app-header', 'visualizer', 'tab-nav']);
-  await loadTemplates([
-    'tab-inputs-template',
-    'tab-presets-template',
-    'tab-summary-template',
-    'tab-finishing-template',
-    'tab-scores-template',
-    'tab-perforations-template',
-    'tab-warnings-template',
-    'tab-print-template',
-  ]);
+  const fragmentNames = collectFragmentPlaceholders();
+  const templateNames = collectTemplatePlaceholders();
+
+  await loadFragments(fragmentNames);
+  await loadTemplates(templateNames);
   await import('./app.js');
 }
 

--- a/docs/js/utils/fragment-loader.js
+++ b/docs/js/utils/fragment-loader.js
@@ -8,9 +8,14 @@ async function fetchFragmentMarkup(name) {
   return response.text();
 }
 
+const selectFragmentPlaceholder = (name) =>
+  typeof document !== 'undefined'
+    ? document.querySelector(`[data-partial='${name}'], [data-fragment='${name}']`)
+    : null;
+
 async function injectFragment(name) {
   if (typeof document === 'undefined') return null;
-  const placeholder = document.querySelector(`[data-fragment='${name}']`);
+  const placeholder = selectFragmentPlaceholder(name);
   if (!placeholder) return null;
 
   try {

--- a/docs/js/utils/template-loader.js
+++ b/docs/js/utils/template-loader.js
@@ -15,6 +15,18 @@ function extractTemplateElement(markup) {
   return container.querySelector('template');
 }
 
+const ensureTemplateHost = () => {
+  if (typeof document === 'undefined') return null;
+  let host = document.querySelector('[data-template-host]');
+  if (!host) {
+    host = document.createElement('div');
+    host.hidden = true;
+    host.setAttribute('data-template-host', '');
+    document.body.appendChild(host);
+  }
+  return host;
+};
+
 async function injectTemplate(name) {
   if (typeof document === 'undefined') return null;
   const existing = document.getElementById(name);
@@ -27,7 +39,11 @@ async function injectTemplate(name) {
     if (!template) {
       throw new Error(`Template "${name}" did not include a <template> element.`);
     }
-    document.body.appendChild(template);
+    const host = ensureTemplateHost();
+    if (!host) {
+      throw new Error('Unable to locate or create template host container.');
+    }
+    host.appendChild(template);
     return template;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Summary
- replace inline markup in the shell with partial placeholders and a hidden template host
- collect fragment and template placeholders during bootstrap and fetch their HTML on demand
- mount fetched templates into a dedicated hidden host so existing selectors keep working

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_690c453cf0e48324b0337f93e7df4587