### PR TITLE
Fix partial loader paths for fragments and templates

### DIFF
--- a/docs/js/utils/fragment-loader.js
+++ b/docs/js/utils/fragment-loader.js
@@ -1,4 +1,4 @@
-const fragmentUrl = (name) => new URL(`../partials/fragments/${name}.html`, import.meta.url);
+const fragmentUrl = (name) => new URL(`../../partials/fragments/${name}.html`, import.meta.url);
 
 async function fetchFragmentMarkup(name) {
   const response = await fetch(fragmentUrl(name));

--- a/docs/js/utils/template-loader.js
+++ b/docs/js/utils/template-loader.js
@@ -1,4 +1,4 @@
-const templateUrl = (name) => new URL(`../partials/templates/${name}.html`, import.meta.url);
+const templateUrl = (name) => new URL(`../../partials/templates/${name}.html`, import.meta.url);
 
 async function fetchTemplateMarkup(name) {
   const response = await fetch(templateUrl(name));


### PR DESCRIPTION
## Summary
- correct fragment loader URL to resolve from utils directory to shared partials folder
- correct template loader URL to resolve from utils directory to shared partials folder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c4ae0b1c0832484e6a06acf12343a