### PR TITLE
Add program sequence tab and calculations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,7 @@
           <section id="tab-presets" data-tab-template="tab-presets-template"></section>
           <section id="tab-summary" data-tab-template="tab-summary-template"></section>
           <section id="tab-finishing" data-tab-template="tab-finishing-template"></section>
+          <section id="tab-program-sequence" data-tab-template="tab-program-sequence-template"></section>
           <section id="tab-scores" data-tab-template="tab-scores-template"></section>
           <section id="tab-perforations" data-tab-template="tab-perforations-template"></section>
           <section id="tab-warnings" data-tab-template="tab-warnings-template"></section>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -4,6 +4,7 @@ import { initializeTabRegistry, registerTab } from './tabs/registry.js';
 import inputsTab, { isAutoMarginModeEnabled, enableAutoMarginMode } from './tabs/inputs.js';
 import summaryTab from './tabs/summary.js';
 import finishingTab from './tabs/finishing.js';
+import programSequenceTab from './tabs/program-sequence.js';
 import scoresTab from './tabs/scores.js';
 import perforationsTab from './tabs/perforations.js';
 import warningsTab from './tabs/warnings.js';
@@ -29,6 +30,7 @@ import {
   setMeasurementHover,
   toggleMeasurementSelection,
 } from './utils/dom.js';
+import { calculateProgramSequence } from './utils/program-sequence.js';
 
 // ============================================================
 // Kevin’s Bitchin’ Print Calculator — Application Script
@@ -332,6 +334,7 @@ function update() {
     perforationHorizontal: inp.perfH,
     perforationVertical: inp.perfV,
   });
+  const programSequence = calculateProgramSequence(layout);
 
   // Summary
   $("#vAcross").textContent = layout.counts.across;
@@ -349,6 +352,7 @@ function update() {
   fillTable($("#tblScoresV tbody"), fin.scores.vertical, 'score-vertical');
   fillTable($("#tblPerforationsH tbody"), fin.perforations.horizontal, 'perforation-horizontal');
   fillTable($("#tblPerforationsV tbody"), fin.perforations.vertical, 'perforation-vertical');
+  fillTable($("#tblProgramSequence tbody"), programSequence, 'program-sequence');
 
   $("#pSheet").textContent = fmtIn(ctx.sheet.rawWidth) + " × " + fmtIn(ctx.sheet.rawHeight);
   $("#pDoc").textContent = fmtIn(ctx.document.width) + " × " + fmtIn(ctx.document.height);
@@ -571,6 +575,7 @@ const tabRegistrations = [
   { module: inputsTab, context: { update, status } },
   { module: summaryTab, context: {} },
   { module: finishingTab, context: {} },
+  { module: programSequenceTab, context: {} },
   { module: scoresTab, context: { update, status } },
   { module: perforationsTab, context: { update, status } },
   { module: warningsTab, context: {} },

--- a/docs/js/tabs/program-sequence.js
+++ b/docs/js/tabs/program-sequence.js
@@ -1,0 +1,23 @@
+import { hydrateTabPanel } from './registry.js';
+
+const TAB_KEY = 'program-sequence';
+let initialized = false;
+
+function init() {
+  hydrateTabPanel(TAB_KEY);
+  if (initialized) return;
+  initialized = true;
+}
+
+const programSequenceTab = {
+  key: TAB_KEY,
+  init,
+  onActivate() {
+    init();
+  },
+  onRegister() {
+    init();
+  },
+};
+
+export default programSequenceTab;

--- a/docs/js/utils/program-sequence.js
+++ b/docs/js/utils/program-sequence.js
@@ -1,0 +1,98 @@
+import { clampToZero, inchesToMillimeters } from './units.js';
+
+const EPSILON = 1e-6;
+
+const toFinite = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+};
+
+const dedupeSorted = (values = []) => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted.filter((value, index, arr) => {
+    if (index === 0) return true;
+    return Math.abs(value - arr[index - 1]) > EPSILON;
+  });
+};
+
+const positionsToSegments = (positions = []) => {
+  if (!Array.isArray(positions) || positions.length === 0) return [];
+  const normalized = positions
+    .map((pos) => clampToZero(toFinite(pos)))
+    .filter((pos) => pos > EPSILON);
+  if (normalized.length === 0) return [];
+  const unique = dedupeSorted(normalized);
+  const spans = [];
+  let previous = 0;
+  unique.forEach((position) => {
+    const delta = clampToZero(position - previous);
+    if (delta > EPSILON) {
+      spans.push(delta);
+    }
+    previous = position;
+  });
+  return spans;
+};
+
+const buildAxisSegments = ({ leadMargin = 0, docSpan = 0, gutterSpan = 0, count = 0 } = {}) => {
+  const docs = Math.max(0, Math.floor(toFinite(count)));
+  const docSize = clampToZero(toFinite(docSpan));
+  if (docs <= 0 || docSize <= EPSILON) {
+    const margin = clampToZero(toFinite(leadMargin));
+    return margin > EPSILON ? [margin] : [];
+  }
+  const gutterSize = clampToZero(toFinite(gutterSpan));
+  const margin = clampToZero(toFinite(leadMargin));
+  const positions = [];
+  let cursor = margin;
+  if (cursor > EPSILON) positions.push(cursor);
+  for (let i = 0; i < docs; i += 1) {
+    cursor += docSize;
+    positions.push(cursor);
+    if (i < docs - 1 && gutterSize > EPSILON) {
+      cursor += gutterSize;
+      positions.push(cursor);
+    }
+  }
+  return positionsToSegments(positions);
+};
+
+export const calculateProgramSequence = (layout = {}) => {
+  if (!layout || typeof layout !== 'object') return [];
+  const { realizedMargins = {}, document = {}, gutter = {}, counts = {} } = layout;
+
+  const horizontalSegments = buildAxisSegments({
+    leadMargin: realizedMargins.left,
+    docSpan: document.width,
+    gutterSpan: gutter.horizontal,
+    count: counts.across,
+  });
+
+  const verticalSegments = buildAxisSegments({
+    leadMargin: realizedMargins.top,
+    docSpan: document.height,
+    gutterSpan: gutter.vertical,
+    count: counts.down,
+  });
+
+  const rows = [];
+  let step = 1;
+
+  const pushRow = (span, axisLabel) => {
+    if (!(span > EPSILON)) return;
+    const inches = Number(clampToZero(span).toFixed(4));
+    rows.push({
+      label: axisLabel ? `Step ${step} — ${axisLabel}` : `Step ${step}`,
+      inches,
+      millimeters: inchesToMillimeters(inches),
+    });
+    step += 1;
+  };
+
+  horizontalSegments.forEach((segment) => pushRow(segment, 'Horizontal'));
+  verticalSegments.forEach((segment) => pushRow(segment, 'Vertical'));
+
+  return rows;
+};
+
+export default calculateProgramSequence;

--- a/docs/partials/fragments/tab-nav.html
+++ b/docs/partials/fragments/tab-nav.html
@@ -13,6 +13,7 @@
   <div class="output-tab-trigger is-active" data-tab="inputs">Inputs</div>
   <div class="output-tab-trigger" data-tab="summary">Summary</div>
   <div class="output-tab-trigger" data-tab="finishing">Cuts / Slits</div>
+  <div class="output-tab-trigger" data-tab="program-sequence">Program Sequence</div>
   <div class="output-tab-trigger" data-tab="scores">Scores</div>
   <div class="output-tab-trigger" data-tab="perforations">Perforations</div>
   <div class="output-tab-trigger" data-tab="warnings">Warnings</div>

--- a/docs/partials/templates/tab-program-sequence-template.html
+++ b/docs/partials/templates/tab-program-sequence-template.html
@@ -1,0 +1,21 @@
+<!--
+  Load timing:
+    - Hydrated into #tab-program-sequence by the tab registry when the Program
+      Sequence tab is registered or activated.
+  Key selectors:
+    - #tblProgramSequence tbody receives measurement rows via fillTable.
+  JS dependencies:
+    - docs/js/app.js supplies the data table rows through calculateProgramSequence.
+-->
+
+<template id="tab-program-sequence-template">
+  <div class="data-card">
+    <h3>Program Sequence</h3>
+    <table class="data-table" id="tblProgramSequence">
+      <thead>
+        <tr><th>Step</th><th>in</th><th>mm</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add a program sequence utility that derives cutter steps from the calculated layout
- create a program sequence tab template and navigation entry to display the sequence table
- register the tab in the app shell and populate its table during updates

## Testing
- node --input-type=module - <<'NODE'
import { calculateProgramSequence } from './docs/js/utils/program-sequence.js';

const layout = {
  realizedMargins: { left: 0.0625, right: 1.1875, top: 0.0625, bottom: 1.0625 },
  document: { width: 3.5, height: 2 },
  gutter: { horizontal: 0.125, vertical: 0.125 },
  counts: { across: 3, down: 8 },
};

const sequence = calculateProgramSequence(layout);
console.log(sequence.slice(0, 8));
console.log(sequence.length);
NODE

------
https://chatgpt.com/codex/tasks/task_e_690c52e8f4bc8324acc0b99bcb843dd2