### PR TITLE
Introduce stack/grid layout utilities

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -65,6 +65,18 @@
   --shadow-deep: color-mix(in srgb, var(--text-inverse) 25%, transparent);
   --surface-paper: #fff;
 
+  /* Layout spacing tokens */
+  --stack-gap-default: 12px;
+  --stack-gap-tight: 8px;
+  --stack-gap-snug: 6px;
+  --stack-gap-comfortable: 16px;
+  --stack-gap-spacious: 18px;
+  --grid-gap-default: 12px;
+  --grid-gap-tight: 8px;
+  --grid-gap-snug: 6px;
+  --grid-gap-comfortable: 16px;
+  --grid-gap-spacious: 18px;
+
   /* Legacy aliases */
   --bg: var(--surface-bg);
   --panel: var(--surface-panel);
@@ -118,23 +130,77 @@ h3 {
  * Grid helpers and panels that shape the main
  * calculator layout.
  * ============================================= */
+/* Flex column utility shared by stacked layouts throughout the UI. */
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap, var(--stack-gap-default));
+}
+
+/* Gap modifiers tune spacing without redefining structural rules. */
+.stack--compact {
+  --stack-gap: var(--stack-gap-tight);
+}
+
+.stack--snug {
+  --stack-gap: var(--stack-gap-snug);
+}
+
+.stack--roomy {
+  --stack-gap: var(--stack-gap-comfortable);
+}
+
+.stack--spacious {
+  --stack-gap: var(--stack-gap-spacious);
+}
+
+/* Grid utility shared by content groupings that rely on CSS grid layouts. */
+.grid {
+  display: grid;
+  gap: var(--grid-gap, var(--grid-gap-default));
+}
+
+.grid--compact {
+  --grid-gap: var(--grid-gap-tight);
+}
+
+.grid--snug {
+  --grid-gap: var(--grid-gap-snug);
+}
+
+.grid--roomy {
+  --grid-gap: var(--grid-gap-comfortable);
+}
+
+.grid--spacious {
+  --grid-gap: var(--grid-gap-spacious);
+}
+
+.grid--auto-fit {
+  grid-template-columns: repeat(auto-fit, minmax(var(--grid-min, 240px), 1fr));
+}
+
+.grid--auto-fill {
+  grid-template-columns: repeat(auto-fill, minmax(var(--grid-min, 150px), 1fr));
+}
+
+.grid--columns-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 /* This class wraps the entire calculator experience, establishing the page centering and stacking rhythm. */
 .layout-app-shell {
   max-width: 1280px;
   margin: 0 auto;
   padding: 16px 18px 24px;
   min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+  --stack-gap: var(--stack-gap-spacious);
 }
 
 /* This class formats the top header section that introduces the calculator. */
 .layout-app-header {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
   padding: 4px 6px 0;
+  --stack-gap: 4px;
 }
 
 /* This descendant rule limits header body copy width for readability. */
@@ -143,26 +209,9 @@ h3 {
   max-width: 640px;
 }
 
-/* This utility class creates grid layouts for cards and content groupings. */
-.layout-grid-group {
-  display: grid;
-  gap: 12px;
-}
-
-/* This utility class stacks children vertically with customizable spacing. */
-.layout-stack {
-  display: flex;
-  flex-direction: column;
-  gap: var(--stack-gap, 12px);
-}
-
-/* This modifier tightens spacing for compact stack layouts. */
-.layout-stack-compact {
-  --stack-gap: 8px;
-}
-
 /* This rule removes extra spacing when toolbars render inside stacked cards. */
-.layout-stack .control-toolbar, .layout-stack .visualizer-visibility-toggles {
+.stack .control-toolbar,
+.stack .visualizer-visibility-toggles {
   margin: 0;
 }
 
@@ -170,9 +219,7 @@ h3 {
 .input-scroll-container {
   flex: 1;
   min-height: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  --stack-gap: 16px;
   overflow-y: auto;
   padding-right: 6px;
 }
@@ -209,16 +256,12 @@ h3 {
 
 /* This class structures the visualizer section that houses the preview canvas and legend. */
 .sheet-preview-visualizer {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  --stack-gap: 12px;
 }
 
 /* This class governs the tabbed analysis section that follows the preview. */
 .output-details-section {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
+  --stack-gap: 0;
 }
 
 /* =============================================
@@ -305,9 +348,7 @@ h3 {
 
 /* This container groups the input cards and supporting descriptions. */
 .input-layout-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  --stack-gap: 16px;
 }
 
 /* This header styling keeps intro copy aligned with the pane layout. */
@@ -318,37 +359,30 @@ h3 {
 
 /* This grid arranges configuration cards responsively based on available width. */
 .input-card-grid {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  --grid-min: 240px;
 }
 
 /* This container stacks the preview canvas, its controls, and legend. */
 .sheet-preview-container {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  --stack-gap: 8px;
 }
 
 /* This grid arranges input fields into flexible, multi-column rows. */
 .input-field-row {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px;
+  --grid-min: 120px;
+  --grid-gap: var(--grid-gap-tight);
 }
 
 /* This variation supports four-up field clusters with narrower minimum widths. */
 .input-field-row-quad {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  gap: 8px;
+  --grid-min: 100px;
+  --grid-gap: var(--grid-gap-tight);
 }
 
 /* This helper distributes form controls evenly based on available width. */
 .input-field-row-auto {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 6px;
+  --grid-gap: var(--grid-gap-snug);
+  --grid-min: 150px;
 }
 
 @media (max-width: 900px) {

--- a/docs/css/tabs/finishing.css
+++ b/docs/css/tabs/finishing.css
@@ -7,24 +7,19 @@
 
 /* This container stacks score planning panels and supplemental results. */
 .finishing-score-pane {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+  --stack-gap: var(--stack-gap-spacious);
 }
 
 /* This layout splits inputs and results into columns for large screens. */
 .finishing-score-layout {
-  display: grid;
-  gap: 18px;
+  --grid-gap: var(--grid-gap-spacious);
   grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
   align-items: start;
 }
 
 /* Each column stacks cards in the scoring and perforation tabs. */
 .finishing-score-column {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+  --stack-gap: var(--stack-gap-spacious);
 }
 
 /* This card introduces the scoring/perforation section with contextual copy. */
@@ -34,7 +29,7 @@
 
 /* This modifier adds breathing room between result cards. */
 .finishing-score-results {
-  gap: 16px;
+  --stack-gap: var(--stack-gap-comfortable);
 }
 
 /* This base card adds vertical rhythm for score configuration forms. */
@@ -81,9 +76,7 @@
 
 /* This container stacks score input labels and helper copy. */
 .finishing-score-field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  --stack-gap: var(--stack-gap-snug);
 }
 
 /* Score labels switch to a column layout for multi-line instructions. */
@@ -154,9 +147,8 @@
 
 /* Result grids arrange tables responsively based on available width. */
 .finishing-score-results-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  --grid-gap: var(--grid-gap-comfortable);
+  --grid-min: 260px;
 }
 
 @media (max-width: 960px) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,14 +10,14 @@
     <link rel="stylesheet" href="./css/style.css" />
   </head>
   <body>
-    <div class="layout-app-shell">
+    <div class="layout-app-shell stack">
       <!-- Fragment placeholder: App header -->
       <div data-partial="app-header"></div>
 
       <!-- Fragment placeholder: Sheet preview visualizer -->
       <div data-partial="visualizer"></div>
 
-      <main class="content-section output-details-section">
+      <main class="content-section output-details-section stack">
         <!-- Fragment placeholder: Output tab navigation -->
         <div data-partial="tab-nav"></div>
 

--- a/docs/partials/fragments/app-header.html
+++ b/docs/partials/fragments/app-header.html
@@ -9,7 +9,7 @@
     - No direct scripts target this fragment; it simply occupies the shell header space
       once the fragment loader swaps it in.
 -->
-<header class="layout-app-header">
+<header class="layout-app-header stack">
   <h1>Kevin’s Bitchin’ Print Calculator</h1>
   <p class="text-muted-detail">Dial in your sheet specs, finishing steps, and print-ready outputs from one bitchin’ workspace.</p>
 </header>

--- a/docs/partials/fragments/visualizer.html
+++ b/docs/partials/fragments/visualizer.html
@@ -11,8 +11,8 @@
     - docs/js/tabs/summary.js hydrates visibility toggles via get/setLayerVisibility helpers.
     - docs/js/app.js and docs/js/utils/dom.js query #svg to render and update the sheet preview.
 -->
-<section class="content-section sheet-preview-visualizer">
-  <div class="sheet-preview-container">
+<section class="content-section sheet-preview-visualizer stack">
+  <div class="sheet-preview-container stack">
     <div class="visualizer-visibility-toggles layer-visibility-toolbar print-hidden">
       <label>
         <input class="layer-visibility-toggle-input" type="checkbox" data-layer="layout" checked />

--- a/docs/partials/templates/tab-finishing-template.html
+++ b/docs/partials/templates/tab-finishing-template.html
@@ -10,7 +10,7 @@
 
 <template id="tab-finishing-template">
   <h3 style="margin-bottom:6px">Cut &amp; Slit Systems</h3>
-  <div class="layout-grid-group" style="grid-template-columns:1fr 1fr">
+  <div class="grid grid--columns-2">
     <div class="data-card"><h3>Cuts (Y edges)</h3>
       <table class="data-table" id="tblCuts"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
     </div>

--- a/docs/partials/templates/tab-inputs-template.html
+++ b/docs/partials/templates/tab-inputs-template.html
@@ -13,13 +13,13 @@
 -->
 
 <template id="tab-inputs-template">
-  <div class="input-layout-panel">
+  <div class="input-layout-panel stack">
     <div class="input-panel-header">
       <h2>Input Controls</h2>
       <p class="text-muted-detail">Define the sheet, document, and safety settings to drive the preview.</p>
     </div>
 
-    <div class="input-scroll-container">
+    <div class="input-scroll-container stack">
       <div class="control-toolbar input-unit-controls print-hidden">
         <span>Units:</span>
         <select id="units">
@@ -28,7 +28,7 @@
         </select>
       </div>
 
-      <div class="input-card-grid">
+      <div class="input-card-grid grid grid--auto-fit">
         <div class="data-card">
           <h2>Sheet</h2>
           <div class="control-toolbar preset-selector-toolbar print-hidden">
@@ -39,7 +39,7 @@
               </select>
             </label>
           </div>
-          <div class="input-field-row">
+          <div class="input-field-row grid grid--auto-fit grid--compact">
             <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25"></label>
             <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25"></label>
           </div>
@@ -55,7 +55,7 @@
               </select>
             </label>
           </div>
-          <div class="input-field-row">
+          <div class="input-field-row grid grid--auto-fit grid--compact">
             <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125"></label>
             <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125"></label>
           </div>
@@ -71,7 +71,7 @@
               </select>
             </label>
           </div>
-          <div class="input-field-row">
+          <div class="input-field-row grid grid--auto-fit grid--compact">
             <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625"></label>
             <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625"></label>
           </div>
@@ -79,7 +79,7 @@
 
         <div class="data-card">
           <h2>Docs (limit)</h2>
-          <div class="input-field-row">
+          <div class="input-field-row grid grid--auto-fit grid--compact">
             <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
             <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
           </div>
@@ -87,7 +87,7 @@
 
         <div class="data-card">
           <h2>Margins (inside printable)</h2>
-          <div class="input-field-row-quad">
+          <div class="input-field-row-quad grid grid--auto-fit grid--compact">
             <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
             <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
             <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
@@ -97,7 +97,7 @@
 
         <div class="data-card">
           <h2>Non‑Printable Area</h2>
-          <div class="input-field-row-quad">
+          <div class="input-field-row-quad grid grid--auto-fit grid--compact">
             <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625"></label>
             <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625"></label>
             <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625"></label>

--- a/docs/partials/templates/tab-perforations-template.html
+++ b/docs/partials/templates/tab-perforations-template.html
@@ -10,16 +10,16 @@
 -->
 
 <template id="tab-perforations-template">
-  <div class="finishing-score-pane">
-    <div class="finishing-score-layout">
-      <div class="finishing-score-column">
-        <div class="data-card layout-stack finishing-score-card-intro">
+  <div class="finishing-score-pane stack">
+    <div class="finishing-score-layout grid">
+      <div class="finishing-score-column stack">
+        <div class="data-card stack finishing-score-card-intro">
           <div class="finishing-score-card-title">
             <h3>Perforation Planning</h3>
             <p class="text-muted-detail">Configure tear-off runs relative to each document before applying them to the layout.</p>
           </div>
         </div>
-        <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
+        <div class="data-card stack finishing-score-card finishing-score-card-vertical">
           <div class="finishing-score-card-header">
             <div class="finishing-score-card-title">
               <h3>Vertical Perforations</h3>
@@ -31,7 +31,7 @@
               <button class="action-button" id="perfPresetVCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field layout-stack-compact">
+          <div class="finishing-score-field stack stack--snug">
             <label class="finishing-score-label" for="perfV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
               <span>Vertical perforations</span>
               <input id="perfV" type="text" placeholder="e.g., 0.5" />
@@ -39,7 +39,7 @@
             <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
           </div>
         </div>
-        <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
+        <div class="data-card stack finishing-score-card finishing-score-card-horizontal">
           <div class="finishing-score-card-header">
             <div class="finishing-score-card-title">
               <h3>Horizontal Perforations</h3>
@@ -51,7 +51,7 @@
               <button class="action-button" id="perfPresetHCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field layout-stack-compact">
+          <div class="finishing-score-field stack stack--snug">
             <label class="finishing-score-label" for="perfH" title="CSV, 0–1">
               <span>Horizontal perforations</span>
               <input id="perfH" type="text" placeholder="e.g., 0.5" />
@@ -66,16 +66,16 @@
           </div>
         </div>
       </div>
-      <div class="finishing-score-column finishing-score-results">
-        <div class="finishing-score-results-grid">
-          <div class="data-card layout-stack finishing-score-table-card">
+      <div class="finishing-score-column stack finishing-score-results">
+        <div class="finishing-score-results-grid grid grid--auto-fit">
+          <div class="data-card stack finishing-score-table-card">
             <div>
               <h3>Perforations (Y)</h3>
               <p class="text-muted-detail">Horizontal perforation runs positioned along the sheet height.</p>
             </div>
             <table class="data-table" id="tblPerforationsH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
           </div>
-          <div class="data-card layout-stack finishing-score-table-card">
+          <div class="data-card stack finishing-score-table-card">
             <div>
               <h3>Perforations (X)</h3>
               <p class="text-muted-detail">Vertical perforation runs positioned along the sheet width.</p>

--- a/docs/partials/templates/tab-presets-template.html
+++ b/docs/partials/templates/tab-presets-template.html
@@ -9,15 +9,15 @@
 -->
 
 <template id="tab-presets-template">
-  <div class="layout-preset-pane">
-    <div class="data-card layout-stack layout-preset-introduction">
+  <div class="layout-preset-pane stack">
+    <div class="data-card stack layout-preset-introduction">
       <h2>Preset Layouts</h2>
       <p class="text-muted-detail">
         Jump-start common production setups with one click. Each preset configures sheet, document, gutters, safety areas, and finishing marks to match the listed specification.
       </p>
     </div>
-    <div class="layout-preset-grid layout-grid-group">
-      <div class="data-card layout-stack layout-preset-card">
+    <div class="layout-preset-grid grid grid--auto-fit">
+      <div class="data-card stack layout-preset-card">
         <div class="layout-preset-card-header">
           <h3>Folded Business Card</h3>
           <p class="text-muted-detail">12×18 sheet, 3.5×5 document, ⅛″ gutters, non-printable margin 1⁄16″.</p>
@@ -28,7 +28,7 @@
         </ul>
         <button class="action-button action-button-primary" data-layout-preset="folded-business-card">Apply preset</button>
       </div>
-      <div class="data-card layout-stack layout-preset-card">
+      <div class="data-card stack layout-preset-card">
         <div class="layout-preset-card-header">
           <h3>Tri-fold Brochure</h3>
           <p class="text-muted-detail">12×18 sheet, 11×8.5 document, 0.25″ gutters, 0.125″ non-printable area.</p>
@@ -38,7 +38,7 @@
         </ul>
         <button class="action-button action-button-primary" data-layout-preset="trifold-brochure">Apply preset</button>
       </div>
-      <div class="data-card layout-stack layout-preset-card">
+      <div class="data-card stack layout-preset-card">
         <div class="layout-preset-card-header">
           <h3>Postcard Gang Run</h3>
           <p class="text-muted-detail">13×19 sheet, 4×6 document, ⅛″ gutters, 0.1″ non-printable area.</p>
@@ -48,7 +48,7 @@
         </ul>
         <button class="action-button action-button-primary" data-layout-preset="postcard-gang-run">Apply preset</button>
       </div>
-      <div class="data-card layout-stack layout-preset-card">
+      <div class="data-card stack layout-preset-card">
         <div class="layout-preset-card-header">
           <h3>Event Tickets</h3>
           <p class="text-muted-detail">12×18 sheet, 2×5.5 document, 0.125″ H / 0.25″ V gutters, 1⁄16″ non-printable.</p>
@@ -58,7 +58,7 @@
         </ul>
         <button class="action-button action-button-primary" data-layout-preset="event-tickets">Apply preset</button>
       </div>
-      <div class="data-card layout-stack layout-preset-card">
+      <div class="data-card stack layout-preset-card">
         <div class="layout-preset-card-header">
           <h3>Table Tents</h3>
           <p class="text-muted-detail">13×19 sheet, 5×7 document, 0.25″ gutters, 0.125″ non-printable area.</p>

--- a/docs/partials/templates/tab-print-template.html
+++ b/docs/partials/templates/tab-print-template.html
@@ -9,7 +9,7 @@
 -->
 
 <template id="tab-print-template">
-  <div class="layout-grid-group">
+  <div class="grid grid--compact">
     <div class="data-card">
       <h3>Summary Snapshot</h3>
       <p class="text-muted-detail">Review the calculated layout details without opening a print dialog.</p>

--- a/docs/partials/templates/tab-scores-template.html
+++ b/docs/partials/templates/tab-scores-template.html
@@ -11,16 +11,16 @@
 -->
 
 <template id="tab-scores-template">
-  <div class="finishing-score-pane">
-    <div class="finishing-score-layout">
-      <div class="finishing-score-column">
-        <div class="data-card layout-stack finishing-score-card-intro">
+  <div class="finishing-score-pane stack">
+    <div class="finishing-score-layout grid">
+      <div class="finishing-score-column stack">
+        <div class="data-card stack finishing-score-card-intro">
           <div class="finishing-score-card-title">
             <h3>Score Planning</h3>
             <p class="text-muted-detail">Scores are normalized to each document. Use a preset for common folds or switch to custom entry to fine-tune the layout.</p>
           </div>
         </div>
-        <div class="data-card layout-stack finishing-score-card finishing-score-card-vertical">
+        <div class="data-card stack finishing-score-card finishing-score-card-vertical">
           <div class="finishing-score-card-header">
             <div class="finishing-score-card-title">
               <h3>Vertical Scores</h3>
@@ -32,7 +32,7 @@
               <button class="action-button" id="scorePresetCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field layout-stack-compact">
+          <div class="finishing-score-field stack stack--snug">
             <label class="finishing-score-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
               <span>Vertical scores</span>
               <input id="scoresV" type="text" placeholder="e.g., 0.5" />
@@ -40,7 +40,7 @@
             <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
           </div>
         </div>
-        <div class="data-card layout-stack finishing-score-card finishing-score-card-horizontal">
+        <div class="data-card stack finishing-score-card finishing-score-card-horizontal">
           <div class="finishing-score-card-header">
             <div class="finishing-score-card-title">
               <h3>Horizontal Scores</h3>
@@ -52,7 +52,7 @@
               <button class="action-button" id="scorePresetHCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field layout-stack-compact">
+          <div class="finishing-score-field stack stack--snug">
             <label class="finishing-score-label" for="scoresH" title="CSV, 0–1">
               <span>Horizontal scores</span>
               <input id="scoresH" type="text" placeholder="e.g., 0.5" />
@@ -68,16 +68,16 @@
           </div>
         </div>
       </div>
-      <div class="finishing-score-column finishing-score-results">
-        <div class="finishing-score-results-grid">
-          <div class="data-card layout-stack finishing-score-table-card">
+      <div class="finishing-score-column stack finishing-score-results">
+        <div class="finishing-score-results-grid grid grid--auto-fit">
+          <div class="data-card stack finishing-score-table-card">
             <div>
               <h3>Scores (Y)</h3>
               <p class="text-muted-detail">Horizontal runs positioned along the sheet height.</p>
             </div>
             <table class="data-table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
           </div>
-          <div class="data-card layout-stack finishing-score-table-card">
+          <div class="data-card stack finishing-score-table-card">
             <div>
               <h3>Scores (X)</h3>
               <p class="text-muted-detail">Vertical runs positioned along the sheet width.</p>

--- a/docs/partials/templates/tab-warnings-template.html
+++ b/docs/partials/templates/tab-warnings-template.html
@@ -8,7 +8,7 @@
 -->
 
 <template id="tab-warnings-template">
-  <div class="data-card layout-stack">
+  <div class="data-card stack">
     <h2>Warnings</h2>
     <p class="text-muted-detail">Production notes and layout warnings will appear here in a future update.</p>
     <p class="text-muted-detail">For now, use this space to track manual adjustments or finishing considerations that fall outside the presets.</p>


### PR DESCRIPTION
## Summary
- add reusable stack and grid utility classes with shared spacing tokens
- update global and finishing layouts to consume the new utilities while keeping unique overrides
- refresh templates to reference the stack/grid helpers for consistent markup

## Testing
- Manual UI smoke check via Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_690c5886ea7c8324a0e7d168843ab4a1