### PR TITLE
Align auto-margin input precision with unit formatting

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -15,8 +15,8 @@ import {
   clampToZero,
   toNumber,
   inchesToMillimeters,
+  formatInchesForUnits,
   formatMeasurement,
-  formatMeasurementValue,
 } from './utils/units.js';
 import {
   $,
@@ -322,11 +322,11 @@ function update() {
     });
     layout = calculateLayout(ctx);
     layout = applyCountOverrides(layout, inp.forceAcross, inp.forceDown);
-    const f = (inches) => formatMeasurementValue(inches, inp.units, 3);
-    $("#mTop").value = f(topMargin);
-    $("#mRight").value = f(rightMargin);
-    $("#mBottom").value = f(bottomMargin);
-    $("#mLeft").value = f(leftMargin);
+    const formatMargin = (inches) => formatInchesForUnits(inches, inp.units);
+    $("#mTop").value = formatMargin(topMargin);
+    $("#mRight").value = formatMargin(rightMargin);
+    $("#mBottom").value = formatMargin(bottomMargin);
+    $("#mLeft").value = formatMargin(leftMargin);
   }
 
   resetMeasurementRegistry();

--- a/docs/js/utils/units.js
+++ b/docs/js/utils/units.js
@@ -7,18 +7,38 @@ export const toNumber = (value) => {
   return Number.isFinite(n) ? n : 0;
 };
 
+export const trimTrailingZeros = (str) => {
+  if (typeof str !== 'string' || !str.includes('.')) return str;
+  const stripped = str.replace(/(\.\d*?[1-9])0+$/, '$1').replace(/\.0+$/, '');
+  return stripped === '' ? '0' : stripped;
+};
+
+export const getUnitsPrecision = (units) => (units === 'mm' ? 2 : 3);
+
 export const inchesToMillimeters = (inches, precision = 3) =>
   Number((inches * MM_PER_INCH).toFixed(precision));
 
-export const convertForUnits = (value, units) =>
-  units === 'mm' ? (value * MM_PER_INCH).toFixed(2) : value;
+export const formatUnitsValue = (value, units, precisionOverride) => {
+  if (value == null || value === '') return '';
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return '';
+  const precision = Number.isFinite(precisionOverride) ? precisionOverride : getUnitsPrecision(units);
+  return trimTrailingZeros(numeric.toFixed(precision));
+};
 
-export const describePresetValue = (value, units) =>
-  units === 'mm' ? (value * MM_PER_INCH).toFixed(2) : value.toString();
+export const formatInchesForUnits = (valueInInches, units, precisionOverride) => {
+  if (!Number.isFinite(valueInInches)) return '';
+  const converted = units === 'mm' ? valueInInches * MM_PER_INCH : valueInInches;
+  return formatUnitsValue(converted, units, precisionOverride);
+};
+
+export const convertForUnits = (value, units) => formatInchesForUnits(value, units);
+
+export const describePresetValue = (value, units) => formatInchesForUnits(value, units);
 
 export const formatValueForUnits = (value, units) => {
   if (value == null) return '';
-  if (units === 'mm') return (value * MM_PER_INCH).toFixed(2);
+  if (units === 'mm') return formatUnitsValue(value * MM_PER_INCH, 'mm', 2);
   if (!Number.isFinite(value)) return '';
   return Number(value.toFixed(4)).toString();
 };
@@ -27,7 +47,7 @@ export const getUnitsLabel = (units) => (units === 'mm' ? 'mm' : 'in');
 
 export const formatMeasurementValue = (value, units, precision) => {
   if (!Number.isFinite(value)) return '';
-  const decimals = Number.isFinite(precision) ? precision : units === 'mm' ? 2 : 3;
+  const decimals = Number.isFinite(precision) ? precision : getUnitsPrecision(units);
   const converted = units === 'mm' ? value * MM_PER_INCH : value;
   return converted.toFixed(decimals);
 };


### PR DESCRIPTION
## Summary
- centralize unit precision helpers for shared numeric formatting
- update auto-margin updates to use the shared formatter for millimeter and inch precision
- ensure the inputs tab relies on the shared precision policy when converting values

## Testing
- node --input-type=module -e "import('./docs/js/utils/units.js').then((m) => { console.log('in', m.formatInchesForUnits(1, 'in')); console.log('mm', m.formatInchesForUnits(1, 'mm')); });"
- node --input-type=module -e "import('./docs/js/utils/units.js').then((m) => { console.log('in', m.formatInchesForUnits(0.123456, 'in')); console.log('mm', m.formatInchesForUnits(0.123456, 'mm')); });"

------
https://chatgpt.com/codex/tasks/task_e_690cd5b5463c8324bff482c865d38bc0