### PR TITLE
Remove unused inputs tab helpers

### DIFF
--- a/docs/js/tabs/inputs.js
+++ b/docs/js/tabs/inputs.js
@@ -502,16 +502,4 @@ export function enableAutoMarginMode(enabled) {
   setAutoMarginMode(enabled);
 }
 
-export function getCurrentUnitsSelection() {
-  return currentUnitsSelection;
-}
-
-export function setCurrentUnitsSelection(units) {
-  currentUnitsSelection = units;
-}
-
-export function getNumericInputSelectors() {
-  return [...numericInputSelectors];
-}
-
 export default inputsTab;


### PR DESCRIPTION
## Summary
- remove unused helper exports from the inputs tab module to avoid dead code

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690cd8349c5c832483d158567869d4d7