### PR TITLE
Remove unused tab registry exports

### DIFF
--- a/docs/js/tabs/registry.js
+++ b/docs/js/tabs/registry.js
@@ -119,8 +119,3 @@ export function initializeTabRegistry(options = {}) {
   activateTab(initialKey);
 }
 
-export function getActiveTabKey() {
-  return activeTabKey;
-}
-
-export { DEFAULT_TAB_KEY };


### PR DESCRIPTION
## Summary
- remove the unused getActiveTabKey function export from the tab registry module
- stop re-exporting the DEFAULT_TAB_KEY constant

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690cd835ce24832491418c25d3e9ef63