### PR TITLE
Refine inputs tab layout

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -84,6 +84,16 @@
   --grid-gap-comfortable: 16px;
   --grid-gap-spacious: 18px;
 
+  /* Compact spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+
+  /* Type scale helpers */
+  --font-xs: 0.8rem;
+  --font-sm: 0.9rem;
+
   /* Legacy aliases */
   --bg: var(--surface-bg);
   --panel: var(--surface-panel);
@@ -290,9 +300,41 @@ h3 {
   font-size: 0.95rem;
 }
 
-/* This grid arranges configuration cards responsively based on available width. */
-.input-card-grid {
-  --grid-min: 240px;
+/* Compact two-column grid that replaces the bulky cards in the inputs tab. */
+.input-2col-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  align-items: start;
+}
+
+/* Columns stack their groups with consistent spacing. */
+.input-2col-grid .col-left,
+.input-2col-grid .col-right {
+  display: grid;
+  gap: var(--space-4);
+  align-content: start;
+}
+
+/* Lightweight grouping keeps headings and rows aligned without card chrome. */
+.input-2col-grid .group {
+  display: grid;
+  grid-template-rows: auto auto;
+  row-gap: var(--space-2);
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.input-2col-grid .group > h2 {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  margin: 0 0 var(--space-1);
+  opacity: 0.9;
+}
+
+.input-2col-grid .control-toolbar {
+  margin: 0;
 }
 
 /* This container stacks the preview canvas, its controls, and legend. */
@@ -300,22 +342,50 @@ h3 {
   --stack-gap: 8px;
 }
 
-/* This grid arranges input fields into flexible, multi-column rows. */
-.input-field-row {
-  --grid-min: 120px;
-  --grid-gap: var(--grid-gap-tight);
+/* Input field rows now rely on explicit grid tracks for consistent density. */
+.input-field-row,
+.input-field-row-quad {
+  display: grid;
+  gap: var(--space-2);
 }
 
-/* This variation supports four-up field clusters with narrower minimum widths. */
+.input-field-row {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .input-field-row-quad {
-  --grid-min: 100px;
-  --grid-gap: var(--grid-gap-tight);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 /* This helper distributes form controls evenly based on available width. */
 .input-field-row-auto {
   --grid-gap: var(--grid-gap-snug);
   --grid-min: 150px;
+}
+
+@media (max-width: 1024px) {
+  .input-2col-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .input-2col-grid .col-left,
+  .input-2col-grid .col-right {
+    gap: var(--space-3);
+  }
+
+  .input-field-row-quad {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .input-field-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .input-field-row-quad {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 @media (max-width: 900px) {
@@ -405,10 +475,44 @@ select {
   width: 100%;
 }
 
+/* Input grid overrides tighten spacing and typography for dense layout. */
+.input-2col-grid label {
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+}
+
+.input-2col-grid label > span {
+  font-size: var(--font-xs);
+  opacity: 0.85;
+  color: var(--text-muted);
+}
+
+.input-2col-grid input,
+.input-2col-grid select {
+  height: 2rem;
+  padding: 0 var(--space-2);
+  font-size: var(--font-sm);
+  line-height: 2rem;
+  width: 100%;
+}
+
+.input-2col-grid input {
+  text-align: right;
+}
+
+.input-2col-grid input.is-invalid,
+.input-2col-grid select.is-invalid {
+  box-shadow: 0 0 0 1px var(--status-danger);
+  background: color-mix(in srgb, var(--status-danger) 12%, transparent);
+}
+
 /* This base class standardizes horizontal control group layouts across the app. */
 .control-toolbar {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   flex-wrap: wrap;
   margin: 0.5rem 0 0;

--- a/docs/html-partials/templates/tab-inputs-template.html
+++ b/docs/html-partials/templates/tab-inputs-template.html
@@ -28,84 +28,87 @@
         </select>
       </div>
 
-      <div class="input-card-grid grid grid--auto-fit">
-        <div class="data-card">
-          <h2>Sheet</h2>
-          <div class="control-toolbar preset-selector-toolbar print-hidden">
-            <label>
-              <span class="text-muted-detail">Preset</span>
-              <select id="sheetPresetSelect" class="preset-selector-control">
-                <option value="">Choose a sheet preset…</option>
-              </select>
-            </label>
-          </div>
-          <div class="input-field-row grid grid--auto-fit grid--compact">
-            <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25"></label>
-            <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25"></label>
-          </div>
+      <div class="input-2col-grid">
+        <div class="col-left">
+          <section class="group">
+            <h2>Sheet</h2>
+            <div class="control-toolbar preset-selector-toolbar print-hidden">
+              <label>
+                <span class="text-muted-detail">Preset</span>
+                <select id="sheetPresetSelect" class="preset-selector-control">
+                  <option value="">Choose a sheet preset…</option>
+                </select>
+              </label>
+            </div>
+            <div class="input-field-row">
+              <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25"></label>
+              <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25"></label>
+            </div>
+          </section>
+
+          <section class="group">
+            <h2>Document</h2>
+            <div class="control-toolbar preset-selector-toolbar print-hidden">
+              <label>
+                <span class="text-muted-detail">Preset</span>
+                <select id="documentPresetSelect" class="preset-selector-control">
+                  <option value="">Choose a document preset…</option>
+                </select>
+              </label>
+            </div>
+            <div class="input-field-row">
+              <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125"></label>
+              <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125"></label>
+            </div>
+          </section>
+
+          <section class="group">
+            <h2>Gutter</h2>
+            <div class="control-toolbar preset-selector-toolbar print-hidden">
+              <label>
+                <span class="text-muted-detail">Preset</span>
+                <select id="gutterPresetSelect" class="preset-selector-control">
+                  <option value="">Choose a gutter preset…</option>
+                </select>
+              </label>
+            </div>
+            <div class="input-field-row">
+              <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625"></label>
+              <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625"></label>
+            </div>
+          </section>
+
+          <section class="group">
+            <h2>Docs (limit)</h2>
+            <div class="input-field-row">
+              <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
+              <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
+            </div>
+          </section>
         </div>
 
-        <div class="data-card">
-          <h2>Document</h2>
-          <div class="control-toolbar preset-selector-toolbar print-hidden">
-            <label>
-              <span class="text-muted-detail">Preset</span>
-              <select id="documentPresetSelect" class="preset-selector-control">
-                <option value="">Choose a document preset…</option>
-              </select>
-            </label>
-          </div>
-          <div class="input-field-row grid grid--auto-fit grid--compact">
-            <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125"></label>
-            <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125"></label>
-          </div>
-        </div>
+        <div class="col-right">
+          <section class="group">
+            <h2>Margins (inside printable)</h2>
+            <div class="input-field-row-quad">
+              <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+              <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+              <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+              <label><span>Left</span><input id="mLeft" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+            </div>
+          </section>
 
-        <div class="data-card">
-          <h2>Gutter</h2>
-          <div class="control-toolbar preset-selector-toolbar print-hidden">
-            <label>
-              <span class="text-muted-detail">Preset</span>
-              <select id="gutterPresetSelect" class="preset-selector-control">
-                <option value="">Choose a gutter preset…</option>
-              </select>
-            </label>
-          </div>
-          <div class="input-field-row grid grid--auto-fit grid--compact">
-            <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625"></label>
-            <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625"></label>
-          </div>
-        </div>
-
-        <div class="data-card">
-          <h2>Docs (limit)</h2>
-          <div class="input-field-row grid grid--auto-fit grid--compact">
-            <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
-            <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
-          </div>
-        </div>
-
-        <div class="data-card">
-          <h2>Margins (inside printable)</h2>
-          <div class="input-field-row-quad grid grid--auto-fit grid--compact">
-            <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-            <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-            <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-            <label><span>Left</span><input id="mLeft" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-          </div>
-        </div>
-
-        <div class="data-card">
-          <h2>Non‑Printable Area</h2>
-          <div class="input-field-row-quad grid grid--auto-fit grid--compact">
-            <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625"></label>
-            <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625"></label>
-            <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625"></label>
-            <label><span>Left</span><input id="npLeft" type="number" step="0.625" data-inch-step="0.625"></label>
-          </div>
+          <section class="group">
+            <h2>Non‑Printable Area</h2>
+            <div class="input-field-row-quad">
+              <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625"></label>
+              <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625"></label>
+              <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625"></label>
+              <label><span>Left</span><input id="npLeft" type="number" step="0.625" data-inch-step="0.625"></label>
+            </div>
+          </section>
         </div>
       </div>
-
       <div class="control-toolbar input-action-toolbar print-hidden">
         <button class="action-button action-button-primary" id="calcBtn">Update Preview</button>
         <button class="action-button" id="resetBtn">Reset</button>


### PR DESCRIPTION
## Summary
- restructure the inputs tab markup to use a lightweight two-column grid while preserving existing form control IDs
- refresh styling for the new grid, including compact spacing, responsive breakpoints, and dense input treatments

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_690ce20ca9e08324a9d627ac701facad