### PR TITLE
Add vitest setup and finishing calculation coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "kevs-calculator",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.3.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Node-based Vitest configuration with an npm test script
- exercise finishing-calculations readouts to confirm inch/mm values and labels
- cover edge cases for zero layouts, sanitized offsets, and zero-gutter positioning

## Testing
- npm test *(fails in CI environment until dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_690ce59e1f34832486a3756c7d09b99d