### PR TITLE
Refactor SVG preview rendering into modular utilities

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -670,6 +670,60 @@ select {
 /* =============================================
  * Preview Stage & Legend
  * ============================================= */
+#svg .svg-line {
+  stroke-linecap: round;
+}
+
+#svg .svg-sheet-outline {
+  fill: none;
+  stroke: #334155;
+  stroke-width: 1.5;
+}
+
+#svg .svg-nonprintable-region {
+  fill: rgba(249, 115, 22, 0.28);
+  stroke: none;
+}
+
+#svg .svg-printable-outline {
+  fill: none;
+  stroke: #f97316;
+  stroke-width: 1;
+}
+
+#svg .svg-layout-area {
+  fill: none;
+  stroke: #38bdf8;
+  stroke-width: 1.5;
+}
+
+#svg .svg-document-area {
+  fill: rgba(94, 234, 212, 0.18);
+  stroke: #5eead4;
+  stroke-width: 1;
+}
+
+#svg .svg-cut-line {
+  stroke: #22d3ee;
+  stroke-width: 1;
+}
+
+#svg .svg-slit-line {
+  stroke: #facc15;
+  stroke-width: 1;
+}
+
+#svg .svg-score-line {
+  stroke: #a855f7;
+  stroke-width: 1;
+}
+
+#svg .svg-perforation-line {
+  stroke: #fb7185;
+  stroke-width: 1;
+  stroke-dasharray: 6 4;
+}
+
 .sheet-preview-layout {
   display: flex;
   gap: 16px;

--- a/docs/js/rendering/svg-layer-attributes.js
+++ b/docs/js/rendering/svg-layer-attributes.js
@@ -1,0 +1,5 @@
+export function applyLayerAttributes(el, layer) {
+  if (!layer) return;
+  el.dataset.layer = layer;
+  el.classList.add('layer', `layer-${layer}`);
+}

--- a/docs/js/rendering/svg-measurement-lines.js
+++ b/docs/js/rendering/svg-measurement-lines.js
@@ -1,0 +1,26 @@
+import {
+  isMeasurementSelected,
+  registerMeasurementId,
+  setMeasurementHover,
+  toggleMeasurementSelection,
+} from '../utils/dom.js';
+
+export function setupMeasurementLine(lineElement, measureId, measureType) {
+  if (!measureId) return;
+
+  registerMeasurementId(measureId);
+  lineElement.dataset.measureId = measureId;
+  lineElement.classList.add('measurement-line');
+
+  if (measureType) {
+    lineElement.dataset.measureType = measureType;
+  }
+
+  if (isMeasurementSelected(measureId)) {
+    lineElement.classList.add('is-selected');
+  }
+
+  lineElement.addEventListener('mouseenter', () => setMeasurementHover(measureId, true));
+  lineElement.addEventListener('mouseleave', () => setMeasurementHover(measureId, false));
+  lineElement.addEventListener('click', () => toggleMeasurementSelection(measureId));
+}

--- a/docs/js/rendering/svg-shape-factories.js
+++ b/docs/js/rendering/svg-shape-factories.js
@@ -1,0 +1,50 @@
+import { applyLayerAttributes } from './svg-layer-attributes.js';
+import { setupMeasurementLine } from './svg-measurement-lines.js';
+
+function addClassNames(el, classNames = []) {
+  if (!classNames) return;
+  if (typeof classNames === 'string') {
+    if (classNames.trim()) {
+      el.classList.add(...classNames.trim().split(/\s+/));
+    }
+    return;
+  }
+  if (Array.isArray(classNames) && classNames.length) {
+    el.classList.add(...classNames.filter(Boolean));
+  }
+}
+
+export function createRectFactory(svg, scale, offsetX, offsetY) {
+  return function drawRect(x, y, width, height, { layer, classNames } = {}) {
+    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('x', offsetX + x * scale);
+    rect.setAttribute('y', offsetY + y * scale);
+    rect.setAttribute('width', Math.max(0.5, width * scale));
+    rect.setAttribute('height', Math.max(0.5, height * scale));
+    rect.setAttribute('rx', 6);
+
+    addClassNames(rect, classNames);
+    applyLayerAttributes(rect, layer);
+    svg.appendChild(rect);
+  };
+}
+
+export function createLineFactory(svg, scale, offsetX, offsetY) {
+  return function drawLine(x1, y1, x2, y2, { layer, classNames, measurement } = {}) {
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', offsetX + x1 * scale);
+    line.setAttribute('y1', offsetY + y1 * scale);
+    line.setAttribute('x2', offsetX + x2 * scale);
+    line.setAttribute('y2', offsetY + y2 * scale);
+
+    line.classList.add('svg-line');
+    addClassNames(line, classNames);
+    applyLayerAttributes(line, layer);
+
+    if (measurement) {
+      setupMeasurementLine(line, measurement.id, measurement.type);
+    }
+
+    svg.appendChild(line);
+  };
+}


### PR DESCRIPTION
## Summary
- split the SVG preview renderer into dedicated modules for layer styling, measurement wiring, and shape factories
- refactor the renderer to rely on CSS class names instead of inline color values while drawing the layout
- define stylesheet rules for SVG preview elements that supply the previous colors and line treatments

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690cfed1f2ac8324a18bbcc5f14b34b1