### PR TITLE
Add drilling planning tab with hole calculations

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -88,6 +88,7 @@
   --measure-margin: #FFA500;        /* Orange — safe area */
   --measure-cut: #FF0000;           /* Red — trim/die */
   --measure-score: #800080;         /* Purple — fold/perf/slit (merged) */
+  --measure-hole: #2563eb;          /* Blue — drilling */
 
   /* Line styles for extra differentiation (esp. grayscale proofs) */
   --line-cut-style: solid;          /* solid red = cut */
@@ -101,12 +102,16 @@
   --measure-cut-bg-selected: color-mix(in srgb, var(--measure-cut) 25%, transparent);
   --measure-score-bg-hover: color-mix(in srgb, var(--measure-score) 15%, transparent);
   --measure-score-bg-selected: color-mix(in srgb, var(--measure-score) 25%, transparent);
+  --measure-hole-bg-hover: color-mix(in srgb, var(--measure-hole) 15%, transparent);
+  --measure-hole-bg-selected: color-mix(in srgb, var(--measure-hole) 25%, transparent);
 
   /* Line glow colors (preview) */
   --measure-cut-glow: #ff6666;        /* light red highlight */
   --measure-score-glow: #c4b5fd;      /* lavender highlight */
   --measure-cut-glow-soft: color-mix(in srgb, var(--measure-cut-glow) 60%, transparent);
   --measure-score-glow-soft: color-mix(in srgb, var(--measure-score-glow) 60%, transparent);
+  --measure-hole-glow: #93c5fd;       /* light blue highlight */
+  --measure-hole-glow-soft: color-mix(in srgb, var(--measure-hole-glow) 60%, transparent);
 
   /* -------------------------------------------------------
      Shadows
@@ -635,6 +640,15 @@ select {
   background: var(--measure-score-bg-selected);
 }
 
+.measurement-row[data-measure-type="hole"].is-hovered,
+.measurement-row[data-measure-type="hole"].is-selected {
+  background: var(--measure-hole-bg-hover);
+}
+
+.measurement-row[data-measure-type="hole"].is-selected {
+  background: var(--measure-hole-bg-selected);
+}
+
 /* Preview lines */
 .measurement-line {
   pointer-events: auto;
@@ -665,6 +679,12 @@ select {
 .measurement-line[data-measure-type="perforation"].is-selected {
   stroke: var(--measure-score-glow);
   filter: drop-shadow(0 0 4px var(--measure-score-glow-soft));
+}
+
+.measurement-line[data-measure-type="hole"].is-hovered,
+.measurement-line[data-measure-type="hole"].is-selected {
+  stroke: var(--measure-hole-glow);
+  filter: drop-shadow(0 0 4px var(--measure-hole-glow-soft));
 }
 
 /* =============================================
@@ -722,6 +742,12 @@ select {
   stroke: #fb7185;
   stroke-width: 1;
   stroke-dasharray: 6 4;
+}
+
+#svg .svg-hole {
+  fill: color-mix(in srgb, var(--measure-hole) 12%, transparent);
+  stroke: var(--measure-hole);
+  stroke-width: 1;
 }
 
 .sheet-preview-layout {
@@ -853,6 +879,7 @@ select {
 .legend-swatch-slits,
 .legend-swatch-perforations    { background: var(--measure-score); }
 .legend-swatch-scores          { background: var(--measure-score); }
+.legend-swatch-holes           { background: var(--measure-hole); }
 
 /* =============================================
  * Print Styles

--- a/docs/css/tabs/drilling.css
+++ b/docs/css/tabs/drilling.css
@@ -1,0 +1,67 @@
+/* =============================================
+ * Drilling Planner
+ * ---------------------------------------------
+ * Layout styles for the hole drilling configuration tab.
+ * ============================================= */
+
+.drilling-configuration-card {
+  --stack-gap: 16px;
+}
+
+.drilling-plan-fields {
+  --grid-gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: flex-end;
+}
+
+.drilling-plan-fields label select {
+  width: 100%;
+}
+
+.drilling-custom-config > p {
+  margin: 0;
+}
+
+.drilling-location-list {
+  --stack-gap: 12px;
+}
+
+.drilling-location-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  align-items: end;
+  padding: 12px;
+  border: 1px solid var(--border-overlay);
+  border-radius: 12px;
+  background: var(--surface-control);
+}
+
+.drilling-location-row .finishing-score-label span {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.drilling-location-row .text-muted-detail {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.drilling-location-row button {
+  align-self: center;
+  justify-self: flex-start;
+}
+
+.drilling-action-card {
+  padding: 0;
+}
+
+.drilling-action-card .finishing-action-toolbar {
+  padding: 12px;
+}
+
+@media (max-width: 720px) {
+  .drilling-location-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/html-partials/fragments/tab-nav.html
+++ b/docs/html-partials/fragments/tab-nav.html
@@ -16,6 +16,7 @@
   <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="program-sequence">Program Sequence</button>
   <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="scores">Scores</button>
   <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="perforations">Perforations</button>
+  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="drilling">Drilling</button>
   <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="warnings">Warnings</button>
   <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="print">Print</button>
   <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="presets">Presets</button>

--- a/docs/html-partials/fragments/visualizer.html
+++ b/docs/html-partials/fragments/visualizer.html
@@ -66,6 +66,13 @@
               <span>Perforations</span>
             </span>
           </label>
+          <label class="layer-visibility-option" data-layer="holes">
+            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="holes" checked />
+            <span class="layer-visibility-label">
+              <i class="legend-color-swatch legend-swatch-holes" aria-hidden="true"></i>
+              <span>Holes</span>
+            </span>
+          </label>
         </div>
       </aside>
     </div>

--- a/docs/html-partials/templates/tab-drilling-template.html
+++ b/docs/html-partials/templates/tab-drilling-template.html
@@ -1,0 +1,90 @@
+<!--
+  Load timing:
+    - Cloned into #tab-drilling when docs/js/tabs/registry.hydrateTabPanel('drilling') runs after bootstrap template loading.
+  Key selectors:
+    - #drillPreset, #drillSize, and #holePlanData store drilling plan controls.
+    - #drillLocations hosts dynamically managed custom hole rows; #drillAddLocation inserts new rows.
+    - #tblHoles renders resolved sheet measurements for drilled holes.
+  JS dependencies:
+    - docs/js/tabs/drilling.js manages preset behavior, hidden state, and update wiring.
+    - docs/js/controllers/layout-updater.js parses #holePlanData and fills #tblHoles with resolved measurements.
+-->
+
+<template id="tab-drilling-template">
+  <div class="finishing-score-pane stack">
+    <div class="finishing-score-layout grid">
+      <div class="finishing-score-column stack">
+        <div class="data-card stack finishing-score-card-intro">
+          <div class="finishing-score-card-title">
+            <h3>Hole Drilling Planner</h3>
+            <p class="text-muted-detail">Define punching patterns that repeat for each document in the layout.</p>
+          </div>
+        </div>
+        <div class="data-card stack drilling-configuration-card">
+          <div class="finishing-score-card-header">
+            <div class="finishing-score-card-title">
+              <h3>Plan Settings</h3>
+              <p class="text-muted-detail">Choose a preset or build a custom plan relative to the document edges.</p>
+            </div>
+          </div>
+          <div class="drilling-plan-fields grid">
+            <label class="finishing-score-label" for="drillPreset">
+              <span>Hole preset</span>
+              <select id="drillPreset">
+                <option value="none">No holes</option>
+                <option value="three-hole">3-hole (left edge)</option>
+                <option value="custom">Custom</option>
+              </select>
+            </label>
+            <label class="finishing-score-label" for="drillSize">
+              <span>Hole size</span>
+              <select id="drillSize">
+                <option value="0.25">1/4 in (0.250)</option>
+                <option value="0.1875">3/16 in (0.1875)</option>
+                <option value="0.3125">5/16 in (0.3125)</option>
+                <option value="0.375">3/8 in (0.375)</option>
+              </select>
+            </label>
+          </div>
+          <div class="drilling-custom-config stack stack--comfortable" data-custom-config hidden>
+            <p class="text-muted-detail">
+              Add hole locations and offsets relative to the document. Alignment determines where the row begins; offsets
+              move the hole along and into the sheet.
+            </p>
+            <div class="drilling-location-list stack stack--comfortable" id="drillLocations"></div>
+            <button class="action-button action-button-secondary" id="drillAddLocation" type="button">Add hole location</button>
+          </div>
+          <input id="holePlanData" type="hidden" value="" />
+        </div>
+        <div class="data-card drilling-action-card">
+          <div class="control-toolbar finishing-action-toolbar print-hidden">
+            <button class="action-button action-button-primary" id="applyDrilling" type="button">Apply Drilling</button>
+            <span class="text-muted-detail">Leave the preset on “No holes” to omit drilling from the layout.</span>
+          </div>
+        </div>
+      </div>
+      <div class="finishing-score-column stack finishing-score-results">
+        <div class="data-card stack finishing-score-table-card">
+          <div>
+            <h3>Hole Locations</h3>
+            <p class="text-muted-detail">Centers are reported from the sheet origin with diameter conversions.</p>
+          </div>
+          <table class="data-table" id="tblHoles">
+            <thead>
+              <tr>
+                <th>Label</th>
+                <th>X (in)</th>
+                <th>Y (in)</th>
+                <th>Ø (in)</th>
+                <th>X (mm)</th>
+                <th>Y (mm)</th>
+                <th>Ø (mm)</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
     <title>Kevin’s Bitchin’ Print Calculator — UI</title>
     <!-- Markup only. Visual styles live in tab bundles and style.css while behavior lives in app.js. -->
     <link rel="stylesheet" href="./css/tabs/finishing.css" />
+    <link rel="stylesheet" href="./css/tabs/drilling.css" />
     <link rel="stylesheet" href="./css/style.css" />
   </head>
   <body>
@@ -28,6 +29,7 @@
           <section id="tab-program-sequence" data-tab-template="tab-program-sequence-template"></section>
           <section id="tab-scores" data-tab-template="tab-scores-template"></section>
           <section id="tab-perforations" data-tab-template="tab-perforations-template"></section>
+          <section id="tab-drilling" data-tab-template="tab-drilling-template"></section>
           <section id="tab-warnings" data-tab-template="tab-warnings-template"></section>
           <section id="tab-print" data-tab-template="tab-print-template"></section>
         </div>

--- a/docs/js/calculations/finishing-calculations.js
+++ b/docs/js/calculations/finishing-calculations.js
@@ -1,5 +1,124 @@
 import { clampToZero, inchesToMillimeters } from '../utils/units.js';
 
+const VALID_HOLE_EDGES = new Set(['top', 'bottom', 'left', 'right']);
+const VALID_HOLE_ALIGNS = new Set(['start', 'center', 'end']);
+
+const clampRange = (value, min, max) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return min;
+  if (min > max) return min;
+  return Math.min(Math.max(numeric, min), max);
+};
+
+const normalizeHoleEntry = (entry = {}) => {
+  const edge = VALID_HOLE_EDGES.has(entry.edge) ? entry.edge : 'left';
+  const align = VALID_HOLE_ALIGNS.has(entry.align) ? entry.align : 'center';
+  const axisOffset = Number(entry.axisOffset);
+  const offset = Number(entry.offset);
+  return {
+    edge,
+    align,
+    axisOffset: Number.isFinite(axisOffset) ? axisOffset : 0,
+    offset: Math.max(0, Number.isFinite(offset) ? offset : 0),
+  };
+};
+
+const resolveAxisCoordinate = (span, align, axisOffset = 0) => {
+  const length = Math.max(0, Number(span) || 0);
+  if (length === 0) return 0;
+  const cleanOffset = Number.isFinite(axisOffset) ? axisOffset : 0;
+  if (align === 'start') {
+    return clampRange(Math.max(0, cleanOffset), 0, length);
+  }
+  if (align === 'end') {
+    return clampRange(length - Math.max(0, cleanOffset), 0, length);
+  }
+  if (align === 'center') {
+    return clampRange(length / 2 + cleanOffset, 0, length);
+  }
+  return clampRange(length / 2, 0, length);
+};
+
+const mapHoleEntryToDocument = (entry, document) => {
+  if (!document || typeof document.width !== 'number' || typeof document.height !== 'number') {
+    return null;
+  }
+  const normalized = normalizeHoleEntry(entry);
+  const width = Math.max(0, document.width);
+  const height = Math.max(0, document.height);
+  if (width === 0 || height === 0) return null;
+
+  switch (normalized.edge) {
+    case 'top':
+      return {
+        x: resolveAxisCoordinate(width, normalized.align, normalized.axisOffset),
+        y: clampRange(normalized.offset, 0, height),
+      };
+    case 'bottom':
+      return {
+        x: resolveAxisCoordinate(width, normalized.align, normalized.axisOffset),
+        y: clampRange(height - Math.max(0, normalized.offset), 0, height),
+      };
+    case 'left':
+      return {
+        x: clampRange(normalized.offset, 0, width),
+        y: resolveAxisCoordinate(height, normalized.align, normalized.axisOffset),
+      };
+    case 'right':
+      return {
+        x: clampRange(width - Math.max(0, normalized.offset), 0, width),
+        y: resolveAxisCoordinate(height, normalized.align, normalized.axisOffset),
+      };
+    default:
+      return null;
+  }
+};
+
+const generateHolePositions = (layout, plan = {}) => {
+  const entries = Array.isArray(plan.entries) ? plan.entries.map(normalizeHoleEntry) : [];
+  const diameter = Number(plan.size);
+  const cleanDiameter = Number.isFinite(diameter) && diameter > 0 ? diameter : 0;
+  if (entries.length === 0 || cleanDiameter <= 0) {
+    return [];
+  }
+
+  const countsAcross = Math.max(0, layout?.counts?.across ?? 0);
+  const countsDown = Math.max(0, layout?.counts?.down ?? 0);
+  if (countsAcross === 0 || countsDown === 0) {
+    return [];
+  }
+
+  const layoutArea = layout.layoutArea ?? {};
+  const gutter = layout.gutter ?? { horizontal: 0, vertical: 0 };
+  const document = layout.document ?? {};
+  const horizontalStep = (document.width ?? 0) + clampToZero(gutter.horizontal ?? 0);
+  const verticalStep = (document.height ?? 0) + clampToZero(gutter.vertical ?? 0);
+
+  const holes = [];
+
+  for (let row = 0; row < countsDown; row++) {
+    for (let col = 0; col < countsAcross; col++) {
+      const originX = (layoutArea.originX ?? 0) + col * horizontalStep;
+      const originY = (layoutArea.originY ?? 0) + row * verticalStep;
+      entries.forEach((entry, index) => {
+        const position = mapHoleEntryToDocument(entry, document);
+        if (!position) return;
+        holes.push({
+          label: `Hole ${index + 1} — Doc ${col + 1},${row + 1}`,
+          x: originX + position.x,
+          y: originY + position.y,
+          diameter: cleanDiameter,
+          docAcross: col + 1,
+          docDown: row + 1,
+          holeIndex: index + 1,
+        });
+      });
+    }
+  }
+
+  return holes;
+};
+
 export function generateEdgePositions(startOffset, docSpan, gutterSpan, docCount) {
   if (docCount <= 0) return [];
   const out = [];
@@ -71,6 +190,7 @@ export function calculateFinishing(layout, options = {}) {
     counts.across,
     options.perforationVertical
   );
+  const holes = generateHolePositions(layout, options.holePlan);
   return {
     cuts: mapPositionsToReadout('Cut', hEdges),
     slits: mapPositionsToReadout('Slit', vEdges),
@@ -82,6 +202,7 @@ export function calculateFinishing(layout, options = {}) {
       horizontal: mapPositionsToReadout('Perforation', hPerforations),
       vertical: mapPositionsToReadout('Perforation', vPerforations),
     },
+    holes,
   };
 }
 

--- a/docs/js/init/register-tabs.js
+++ b/docs/js/init/register-tabs.js
@@ -2,6 +2,7 @@ import { layoutPresets } from '../data/layout-presets.js';
 import inputsTab, { enableAutoMarginMode, isAutoMarginModeEnabled } from '../tabs/inputs.js';
 import finishingTab from '../tabs/finishing.js';
 import perforationsTab from '../tabs/perforations.js';
+import drillingTab from '../tabs/drilling.js';
 import presetsTab from '../tabs/presets.js';
 import printTab from '../tabs/print.js';
 import programSequenceTab from '../tabs/program-sequence.js';
@@ -17,6 +18,7 @@ const TAB_REGISTRATIONS = ({ update, status }) => [
   { module: programSequenceTab, context: {} },
   { module: scoresTab, context: { update, status } },
   { module: perforationsTab, context: { update, status } },
+  { module: drillingTab, context: { update, status } },
   { module: warningsTab, context: {} },
   { module: printTab, context: {} },
   {

--- a/docs/js/rendering/svg-preview-renderer.js
+++ b/docs/js/rendering/svg-preview-renderer.js
@@ -4,7 +4,7 @@ import {
   createMeasurementId,
   restoreMeasurementSelections,
 } from '../utils/dom.js';
-import { createLineFactory, createRectFactory } from './svg-shape-factories.js';
+import { createCircleFactory, createLineFactory, createRectFactory } from './svg-shape-factories.js';
 
 function getNonPrintableMetrics(sheet) {
   const nonPrintable = sheet?.nonPrintable ?? {};
@@ -38,6 +38,7 @@ export function drawSVG(layout, fin) {
 
   const drawRect = createRectFactory(svg, scale, offsetX, offsetY);
   const drawLine = createLineFactory(svg, scale, offsetX, offsetY);
+  const drawCircle = createCircleFactory(svg, scale, offsetX, offsetY);
 
   drawRect(0, 0, layout.sheet.rawWidth, layout.sheet.rawHeight, {
     layer: 'sheet',
@@ -211,6 +212,20 @@ export function drawSVG(layout, fin) {
         },
       },
     );
+  });
+
+  (fin.holes ?? []).forEach((hole, index) => {
+    const diameter = Number(hole?.diameter ?? 0);
+    if (!Number.isFinite(diameter) || diameter <= 0) return;
+    const radius = diameter / 2;
+    drawCircle(hole.x ?? 0, hole.y ?? 0, radius, {
+      layer: 'holes',
+      classNames: ['svg-hole'],
+      measurement: {
+        id: createMeasurementId('hole', index),
+        type: 'hole',
+      },
+    });
   });
 
   applyLayerVisibility();

--- a/docs/js/rendering/svg-shape-factories.js
+++ b/docs/js/rendering/svg-shape-factories.js
@@ -48,3 +48,21 @@ export function createLineFactory(svg, scale, offsetX, offsetY) {
     svg.appendChild(line);
   };
 }
+
+export function createCircleFactory(svg, scale, offsetX, offsetY) {
+  return function drawCircle(cx, cy, radius, { layer, classNames, measurement } = {}) {
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', offsetX + cx * scale);
+    circle.setAttribute('cy', offsetY + cy * scale);
+    circle.setAttribute('r', Math.max(0.5, radius * scale));
+
+    addClassNames(circle, classNames);
+    applyLayerAttributes(circle, layer);
+
+    if (measurement) {
+      setupMeasurementLine(circle, measurement.id, measurement.type);
+    }
+
+    svg.appendChild(circle);
+  };
+}

--- a/docs/js/tabs/drilling.js
+++ b/docs/js/tabs/drilling.js
@@ -1,0 +1,378 @@
+import { $ } from '../utils/dom.js';
+import { hydrateTabPanel } from './registry.js';
+
+const TAB_KEY = 'drilling';
+
+const EDGE_OPTIONS = [
+  { value: 'top', label: 'Top edge' },
+  { value: 'bottom', label: 'Bottom edge' },
+  { value: 'left', label: 'Left edge' },
+  { value: 'right', label: 'Right edge' },
+];
+
+const ALIGN_LABELS = {
+  top: { start: 'Left', center: 'Center', end: 'Right' },
+  bottom: { start: 'Left', center: 'Center', end: 'Right' },
+  left: { start: 'Top', center: 'Center', end: 'Bottom' },
+  right: { start: 'Top', center: 'Center', end: 'Bottom' },
+};
+
+const VALID_PRESETS = new Set(['none', 'three-hole', 'custom']);
+const VALID_ALIGNS = new Set(['start', 'center', 'end']);
+
+const HOLE_SIZE_LABELS = new Map([
+  ['0.25', '1/4 in (0.250)'],
+  ['0.1875', '3/16 in (0.1875)'],
+  ['0.3125', '5/16 in (0.3125)'],
+  ['0.375', '3/8 in (0.375)'],
+]);
+
+const DEFAULT_CUSTOM_ENTRY = {
+  edge: 'top',
+  align: 'center',
+  axisOffset: 0,
+  offset: 0.25,
+};
+
+const PRESET_GENERATORS = {
+  none: () => [],
+  'three-hole': () => [
+    { edge: 'left', align: 'start', axisOffset: 0.5, offset: 0.3125 },
+    { edge: 'left', align: 'center', axisOffset: 0, offset: 0.3125 },
+    { edge: 'left', align: 'end', axisOffset: 0.5, offset: 0.3125 },
+  ],
+  custom: (entries = []) => (entries.length ? entries : [DEFAULT_CUSTOM_ENTRY]),
+};
+
+let initialized = false;
+let storedContext = { update: () => {}, status: () => {} };
+let elements = {};
+let currentConfig = {
+  preset: 'none',
+  size: 0.25,
+  entries: [],
+};
+
+const getUpdate = () => storedContext.update ?? (() => {});
+const getStatus = () => storedContext.status ?? (() => {});
+
+const toNumber = (value, fallback = 0) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const normalizeEntry = (entry = {}) => {
+  const edge = EDGE_OPTIONS.some((opt) => opt.value === entry.edge) ? entry.edge : 'left';
+  const align = VALID_ALIGNS.has(entry.align) ? entry.align : 'center';
+  const axisOffset = toNumber(entry.axisOffset, 0);
+  const offset = Math.max(0, toNumber(entry.offset, 0));
+  return { edge, align, axisOffset, offset };
+};
+
+const resolvePresetEntries = (preset, entries = []) => {
+  const generator = PRESET_GENERATORS[preset] ?? PRESET_GENERATORS.none;
+  const generated = generator(entries).map(normalizeEntry);
+  return generated;
+};
+
+const normalizeConfig = (config = {}) => {
+  const preset = VALID_PRESETS.has(config.preset) ? config.preset : 'none';
+  const size = toNumber(config.size, currentConfig.size ?? 0.25);
+  const diameter = size > 0 ? size : 0.25;
+  const rawEntries = Array.isArray(config.entries) ? config.entries : [];
+  const entries = preset === 'custom' ? rawEntries.map(normalizeEntry) : resolvePresetEntries(preset);
+  return { preset, size: diameter, entries };
+};
+
+const setHiddenValue = () => {
+  if (!elements.hiddenInput) return;
+  try {
+    elements.hiddenInput.value = JSON.stringify(currentConfig);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to serialize drilling config', error);
+  }
+};
+
+const toggleCustomContainer = (show) => {
+  if (!elements.customContainer) return;
+  elements.customContainer.hidden = !show;
+};
+
+const createOption = (value, label) => {
+  const option = document.createElement('option');
+  option.value = value;
+  option.textContent = label;
+  return option;
+};
+
+const updateAlignOptions = (select, edge, selected) => {
+  if (!select) return;
+  const labels = ALIGN_LABELS[edge] ?? ALIGN_LABELS.left;
+  const currentValue = selected ?? select.value;
+  select.innerHTML = '';
+  ['start', 'center', 'end'].forEach((value) => {
+    const option = createOption(value, labels[value] ?? value);
+    if (value === currentValue) {
+      option.selected = true;
+    }
+    select.appendChild(option);
+  });
+};
+
+const createFieldLabel = (text) => {
+  const label = document.createElement('label');
+  label.className = 'finishing-score-label';
+  const span = document.createElement('span');
+  span.textContent = text;
+  label.appendChild(span);
+  return label;
+};
+
+const createHint = (text) => {
+  const hint = document.createElement('p');
+  hint.className = 'text-muted-detail';
+  hint.textContent = text;
+  return hint;
+};
+
+const collectLocationRows = () =>
+  Array.from(elements.locationsContainer?.querySelectorAll('.drilling-location-row') ?? []);
+
+const readEntriesFromUI = () =>
+  collectLocationRows().map((row) => {
+    const edge = row.querySelector('[data-role="edge"]')?.value ?? 'left';
+    const align = row.querySelector('[data-role="align"]')?.value ?? 'center';
+    const axisOffset = toNumber(row.querySelector('[data-role="axis-offset"]')?.value, 0);
+    const offset = toNumber(row.querySelector('[data-role="offset"]')?.value, 0);
+    return normalizeEntry({ edge, align, axisOffset, offset });
+  });
+
+const onCustomEntriesChanged = (statusMessage = null) => {
+  if (currentConfig.preset !== 'custom') {
+    currentConfig = normalizeConfig({ ...currentConfig, preset: 'custom' });
+  }
+  const entries = readEntriesFromUI();
+  currentConfig = normalizeConfig({ ...currentConfig, preset: 'custom', entries });
+  setHiddenValue();
+  getUpdate()();
+  if (statusMessage) {
+    getStatus()(statusMessage);
+  }
+};
+
+const createLocationRow = (entry) => {
+  const row = document.createElement('div');
+  row.className = 'drilling-location-row';
+
+  const edgeLabel = createFieldLabel('Edge');
+  const edgeSelect = document.createElement('select');
+  edgeSelect.dataset.role = 'edge';
+  EDGE_OPTIONS.forEach((opt) => {
+    const option = createOption(opt.value, opt.label);
+    if (opt.value === entry.edge) option.selected = true;
+    edgeSelect.appendChild(option);
+  });
+  edgeLabel.appendChild(edgeSelect);
+  row.appendChild(edgeLabel);
+
+  const alignLabel = createFieldLabel('Alignment');
+  const alignSelect = document.createElement('select');
+  alignSelect.dataset.role = 'align';
+  updateAlignOptions(alignSelect, entry.edge, entry.align);
+  alignLabel.appendChild(alignSelect);
+  row.appendChild(alignLabel);
+
+  const axisWrapper = document.createElement('div');
+  axisWrapper.className = 'stack stack--snug';
+  const axisLabel = createFieldLabel('Along-edge offset (in)');
+  const axisInput = document.createElement('input');
+  axisInput.type = 'number';
+  axisInput.step = '0.01';
+  axisInput.value = String(entry.axisOffset ?? 0);
+  axisInput.dataset.role = 'axis-offset';
+  axisLabel.appendChild(axisInput);
+  axisWrapper.appendChild(axisLabel);
+  axisWrapper.appendChild(createHint('Measured from the selected alignment along the edge.'));
+  row.appendChild(axisWrapper);
+
+  const offsetWrapper = document.createElement('div');
+  offsetWrapper.className = 'stack stack--snug';
+  const offsetLabel = createFieldLabel('Edge offset (in)');
+  const offsetInput = document.createElement('input');
+  offsetInput.type = 'number';
+  offsetInput.step = '0.01';
+  offsetInput.min = '0';
+  offsetInput.value = String(entry.offset ?? 0);
+  offsetInput.dataset.role = 'offset';
+  offsetLabel.appendChild(offsetInput);
+  offsetWrapper.appendChild(offsetLabel);
+  offsetWrapper.appendChild(createHint('Distance into the document from the chosen edge.'));
+  row.appendChild(offsetWrapper);
+
+  const removeButton = document.createElement('button');
+  removeButton.type = 'button';
+  removeButton.className = 'action-button action-button-ghost drilling-remove-location';
+  removeButton.dataset.role = 'remove';
+  removeButton.textContent = 'Remove';
+  row.appendChild(removeButton);
+
+  edgeSelect.addEventListener('change', () => {
+    updateAlignOptions(alignSelect, edgeSelect.value, alignSelect.value);
+    onCustomEntriesChanged('Updated hole edge');
+  });
+  alignSelect.addEventListener('change', () => onCustomEntriesChanged('Updated hole alignment'));
+  axisInput.addEventListener('input', () => onCustomEntriesChanged());
+  offsetInput.addEventListener('input', () => onCustomEntriesChanged());
+  removeButton.addEventListener('click', () => {
+    row.remove();
+    onCustomEntriesChanged('Removed hole location');
+  });
+
+  return row;
+};
+
+const renderCustomEntries = () => {
+  if (!elements.locationsContainer) return;
+  elements.locationsContainer.innerHTML = '';
+  currentConfig.entries.forEach((entry) => {
+    const row = createLocationRow(entry);
+    elements.locationsContainer.appendChild(row);
+  });
+};
+
+const syncUIFromConfig = () => {
+  if (elements.presetSelect) {
+    elements.presetSelect.value = currentConfig.preset;
+  }
+  if (elements.sizeSelect) {
+    elements.sizeSelect.value = String(currentConfig.size);
+  }
+  toggleCustomContainer(currentConfig.preset === 'custom');
+  if (currentConfig.preset === 'custom') {
+    if (currentConfig.entries.length === 0) {
+      currentConfig = normalizeConfig({
+        ...currentConfig,
+        entries: PRESET_GENERATORS.custom(currentConfig.entries),
+      });
+      setHiddenValue();
+    }
+    renderCustomEntries();
+  } else if (elements.locationsContainer) {
+    elements.locationsContainer.innerHTML = '';
+  }
+};
+
+const applyConfig = (config, { silent = false, statusMessage = null } = {}) => {
+  let merged = normalizeConfig({ ...currentConfig, ...config });
+  if (merged.preset === 'custom' && merged.entries.length === 0) {
+    merged = normalizeConfig({ ...merged, entries: PRESET_GENERATORS.custom(merged.entries) });
+  }
+  currentConfig = merged;
+  syncUIFromConfig();
+  setHiddenValue();
+  if (!silent) {
+    getUpdate()();
+    if (statusMessage) {
+      getStatus()(statusMessage);
+    }
+  }
+};
+
+const handlePresetChange = () => {
+  const preset = elements.presetSelect?.value ?? 'none';
+  if (!VALID_PRESETS.has(preset)) return;
+  const statusMessage =
+    preset === 'custom'
+      ? 'Custom hole drilling enabled'
+      : preset === 'three-hole'
+        ? '3-hole drilling preset applied'
+        : 'Hole drilling disabled';
+  const entries = preset === 'custom' ? currentConfig.entries : undefined;
+  applyConfig({ preset, entries }, { statusMessage });
+};
+
+const handleSizeChange = () => {
+  const raw = elements.sizeSelect?.value;
+  const label = raw ? HOLE_SIZE_LABELS.get(raw) ?? `${Number(raw)} in` : null;
+  applyConfig({ size: toNumber(raw, currentConfig.size) }, {
+    statusMessage: label ? `Hole size set to ${label}` : 'Hole size updated',
+  });
+};
+
+const handleAddLocation = () => {
+  const base = currentConfig.entries[currentConfig.entries.length - 1] ?? DEFAULT_CUSTOM_ENTRY;
+  const nextEntry = { ...base };
+  applyConfig({ preset: 'custom', entries: [...currentConfig.entries, nextEntry] }, {
+    statusMessage: 'Added hole location',
+  });
+};
+
+const parseHiddenConfig = () => {
+  if (!elements.hiddenInput) return null;
+  const raw = elements.hiddenInput.value;
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to parse saved drilling config', error);
+  }
+  return null;
+};
+
+const init = (context = {}) => {
+  hydrateTabPanel(TAB_KEY);
+  storedContext = { ...storedContext, ...context };
+  if (initialized) {
+    syncUIFromConfig();
+    return;
+  }
+
+  elements = {
+    presetSelect: $('#drillPreset'),
+    sizeSelect: $('#drillSize'),
+    customContainer: document.querySelector('[data-custom-config]'),
+    locationsContainer: $('#drillLocations'),
+    addButton: $('#drillAddLocation'),
+    applyButton: $('#applyDrilling'),
+    hiddenInput: $('#holePlanData'),
+  };
+
+  const saved = parseHiddenConfig();
+  currentConfig = normalizeConfig(saved ?? currentConfig);
+  syncUIFromConfig();
+  setHiddenValue();
+
+  elements.presetSelect?.addEventListener('change', handlePresetChange);
+  elements.sizeSelect?.addEventListener('change', handleSizeChange);
+  elements.addButton?.addEventListener('click', () => {
+    handleAddLocation();
+    if (elements.locationsContainer?.lastElementChild) {
+      elements.locationsContainer.lastElementChild.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  });
+  elements.applyButton?.addEventListener('click', () => {
+    setHiddenValue();
+    getUpdate()();
+    getStatus()('Hole plan applied to layout');
+  });
+
+  initialized = true;
+};
+
+const drillingTab = {
+  key: TAB_KEY,
+  init,
+  onActivate(context) {
+    init(context);
+  },
+  onRegister(context) {
+    init(context);
+  },
+};
+
+export default drillingTab;

--- a/docs/js/utils/dom.js
+++ b/docs/js/utils/dom.js
@@ -1,3 +1,5 @@
+import { inchesToMillimeters } from './units.js';
+
 export const $ = (selector) => document.querySelector(selector);
 export const $$ = (selector) => Array.from(document.querySelectorAll(selector));
 
@@ -9,6 +11,7 @@ const layerVisibility = {
   slits: true,
   scores: true,
   perforations: true,
+  holes: true,
 };
 
 const selectedMeasurements = new Set();
@@ -108,6 +111,37 @@ export const fillTable = (tbody, rows, type = 'measure') => {
         `<td class="k">${row.millimeters.toFixed(2)}</td>`,
       ];
       return `<tr class="measurement-row" data-measure-id="${id}" data-measure-type="${type}" data-measure-index="${index}">${cells.join('')}</tr>`;
+    })
+    .join('');
+  tbody.querySelectorAll('tr[data-measure-id]').forEach((row) => {
+    attachMeasurementRowInteractions(row);
+    if (isMeasurementSelected(row.dataset.measureId)) {
+      row.classList.add('is-selected');
+    }
+  });
+};
+
+export const fillHoleTable = (tbody, holes = []) => {
+  if (!tbody) return;
+  const rows = Array.isArray(holes) ? holes : [];
+  tbody.innerHTML = rows
+    .map((hole, index) => {
+      const id = createMeasurementId('hole', index);
+      registerMeasurementId(id);
+      const label = hole?.label ?? `Hole ${index + 1}`;
+      const x = Number(hole?.x ?? 0);
+      const y = Number(hole?.y ?? 0);
+      const diameter = Math.max(0, Number(hole?.diameter ?? 0));
+      const cells = [
+        `<td>${label}</td>`,
+        `<td class="k">${x.toFixed(3)}</td>`,
+        `<td class="k">${y.toFixed(3)}</td>`,
+        `<td class="k">${diameter.toFixed(3)}</td>`,
+        `<td class="k">${inchesToMillimeters(x).toFixed(2)}</td>`,
+        `<td class="k">${inchesToMillimeters(y).toFixed(2)}</td>`,
+        `<td class="k">${inchesToMillimeters(diameter).toFixed(2)}</td>`,
+      ];
+      return `<tr class="measurement-row" data-measure-id="${id}" data-measure-type="hole" data-measure-index="${index}">${cells.join('')}</tr>`;
     })
     .join('');
   tbody.querySelectorAll('tr[data-measure-id]').forEach((row) => {

--- a/tests/finishing-calculations.test.js
+++ b/tests/finishing-calculations.test.js
@@ -81,6 +81,8 @@ describe('finishing calculations integration', () => {
       }))
     );
 
+    expect(result.holes).toEqual([]);
+
     const readouts = [
       ...result.cuts,
       ...result.slits,
@@ -93,6 +95,41 @@ describe('finishing calculations integration', () => {
     readouts.forEach(({ inches, millimeters }) => {
       expect(millimeters).toBeCloseTo(mm(inches), 3);
     });
+  });
+});
+
+describe('hole drilling generation', () => {
+  it('produces hole centers for each document using edge alignment and offsets', () => {
+    const layout = {
+      layoutArea: { originX: 1, originY: 2 },
+      counts: { across: 2, down: 2 },
+      document: { width: 4, height: 6 },
+      gutter: { horizontal: 1, vertical: 2 },
+    };
+
+    const holePlan = {
+      size: 0.25,
+      entries: [
+        { edge: 'left', align: 'start', axisOffset: 0.5, offset: 0.3125 },
+        { edge: 'left', align: 'center', axisOffset: 0, offset: 0.3125 },
+        { edge: 'left', align: 'end', axisOffset: 0.5, offset: 0.3125 },
+      ],
+    };
+
+    const result = calculateFinishing(layout, { holePlan });
+
+    expect(result.holes).toHaveLength(12);
+
+    const expectedFirstDoc = [
+      { label: 'Hole 1 — Doc 1,1', x: 1.3125, y: 2.5, diameter: 0.25 },
+      { label: 'Hole 2 — Doc 1,1', x: 1.3125, y: 5, diameter: 0.25 },
+      { label: 'Hole 3 — Doc 1,1', x: 1.3125, y: 7.5, diameter: 0.25 },
+    ];
+
+    expect(result.holes.slice(0, 3)).toMatchObject(expectedFirstDoc);
+
+    const expectedSecondRowFirstDoc = { label: 'Hole 1 — Doc 1,2', x: 1.3125, y: 10.5, diameter: 0.25 };
+    expect(result.holes[6]).toMatchObject(expectedSecondRowFirstDoc);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a drilling planner tab with presets, custom hole locations, and measurement output
- extend finishing calculations, layout updates, and SVG rendering to include hole drilling data and visualization
- expand styling, layer toggles, and tests to cover the new drilling workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690d0ab3acc0832485a486c5fb659be5