### PR TITLE
Add summary tab calculators for pads and run planning

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -593,6 +593,112 @@ select {
   font-weight: 600;
 }
 
+.summary-card__title {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+}
+
+.summary-card__metrics {
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.summary-card__metrics > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summary-card__metrics dt {
+  margin: 0;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.summary-card__metrics dd {
+  margin: 0;
+  text-align: right;
+}
+
+.summary-calculator-section {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.summary-calculator-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.summary-calculator__header {
+  margin-bottom: 12px;
+}
+
+.summary-calculator__title {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+}
+
+.summary-calculator__description {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.summary-calculator__form {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.summary-calculator__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.summary-calculator__label {
+  font-weight: 600;
+}
+
+.summary-calculator__field input {
+  width: 100%;
+}
+
+.summary-calculator__hint {
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+}
+
+.summary-calculator__results {
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.summary-calculator__results > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summary-calculator__results dt {
+  margin: 0;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.summary-calculator__results dd {
+  margin: 0;
+  font-weight: 600;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 .data-table { width: 100%; border-collapse: collapse; }
 .data-table th, .data-table td {
   padding: 8px 10px;

--- a/docs/html-partials/templates/tab-summary-template.html
+++ b/docs/html-partials/templates/tab-summary-template.html
@@ -10,19 +10,171 @@
 
 <template id="tab-summary-template">
   <div class="summary-metrics-grid">
-    <div class="data-card"><h3>Counts</h3>
-      <div>Across: <span class="summary-metric-value" id="vAcross">—</span></div>
-      <div>Down: <span class="summary-metric-value" id="vDown">—</span></div>
-      <div>Total: <span class="summary-metric-value" id="vTotal">—</span></div>
-    </div>
-    <div class="data-card"><h3>Layout Area</h3>
-      <div>W × H: <span class="summary-metric-value" id="vLayout">—</span></div>
-      <div>Origin: <span class="summary-metric-value" id="vOrigin">—</span></div>
-      <div>Realized Margins: <span class="summary-metric-value" id="vRealMargins">—</span></div>
-    </div>
-    <div class="data-card"><h3>Utilization</h3>
-      <div>Used W/H: <span class="summary-metric-value" id="vUsed">—</span></div>
-      <div>Trailing W/H: <span class="summary-metric-value" id="vTrail">—</span></div>
-    </div>
+    <article class="data-card summary-card">
+      <h3 class="summary-card__title">Counts</h3>
+      <dl class="summary-card__metrics">
+        <div>
+          <dt>Across</dt>
+          <dd class="summary-metric-value" id="vAcross">—</dd>
+        </div>
+        <div>
+          <dt>Down</dt>
+          <dd class="summary-metric-value" id="vDown">—</dd>
+        </div>
+        <div>
+          <dt>Total</dt>
+          <dd class="summary-metric-value" id="vTotal">—</dd>
+        </div>
+      </dl>
+    </article>
+    <article class="data-card summary-card">
+      <h3 class="summary-card__title">Layout Area</h3>
+      <dl class="summary-card__metrics">
+        <div>
+          <dt>W × H</dt>
+          <dd class="summary-metric-value" id="vLayout">—</dd>
+        </div>
+        <div>
+          <dt>Origin</dt>
+          <dd class="summary-metric-value" id="vOrigin">—</dd>
+        </div>
+        <div>
+          <dt>Realized Margins</dt>
+          <dd class="summary-metric-value" id="vRealMargins">—</dd>
+        </div>
+      </dl>
+    </article>
+    <article class="data-card summary-card">
+      <h3 class="summary-card__title">Utilization</h3>
+      <dl class="summary-card__metrics">
+        <div>
+          <dt>Used W/H</dt>
+          <dd class="summary-metric-value" id="vUsed">—</dd>
+        </div>
+        <div>
+          <dt>Trailing W/H</dt>
+          <dd class="summary-metric-value" id="vTrail">—</dd>
+        </div>
+      </dl>
+    </article>
   </div>
+
+  <section class="summary-calculator-section" aria-label="Production calculators">
+    <div class="summary-calculator-grid">
+      <article class="data-card summary-calculator" data-calculator="pad">
+        <header class="summary-calculator__header">
+          <h3 class="summary-calculator__title">Pad Calculator</h3>
+          <p class="summary-calculator__description">
+            Work out how many press sheets you need to build padded sets.
+          </p>
+        </header>
+        <form class="summary-calculator__form" autocomplete="off">
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">Number of pads</span>
+            <input type="number" inputmode="numeric" min="0" step="1" id="padCount" placeholder="0" />
+          </label>
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">Sheets per pad</span>
+            <input type="number" inputmode="numeric" min="1" step="1" id="padSheets" value="50" />
+            <span class="summary-calculator__hint">Defaulted to 50 finished sheets per pad.</span>
+          </label>
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">N-up (per press sheet)</span>
+            <input type="number" inputmode="numeric" min="1" step="1" id="padNUp" />
+            <span class="summary-calculator__hint">Auto-fills from the current layout.</span>
+          </label>
+        </form>
+        <dl class="summary-calculator__results" aria-live="polite">
+          <div>
+            <dt>Finished pieces</dt>
+            <dd id="padTotalPieces">—</dd>
+          </div>
+          <div>
+            <dt>Press sheets to print</dt>
+            <dd id="padTotalSheets">—</dd>
+          </div>
+          <div>
+            <dt>Overage after padding</dt>
+            <dd id="padRemainder">—</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="data-card summary-calculator" data-calculator="run">
+        <header class="summary-calculator__header">
+          <h3 class="summary-calculator__title">Target Quantity Planner</h3>
+          <p class="summary-calculator__description">
+            Start from a desired finished quantity and include spoilage/overs.
+          </p>
+        </header>
+        <form class="summary-calculator__form" autocomplete="off">
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">Desired finished pieces</span>
+            <input type="number" inputmode="numeric" min="0" step="1" id="runDesired" placeholder="0" />
+          </label>
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">N-up (per press sheet)</span>
+            <input type="number" inputmode="numeric" min="1" step="1" id="runNUp" />
+            <span class="summary-calculator__hint">Auto-fills from the current layout.</span>
+          </label>
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">Spoilage / overs (%)</span>
+            <input type="number" inputmode="decimal" min="0" step="0.1" id="runOvers" value="0" />
+          </label>
+        </form>
+        <dl class="summary-calculator__results" aria-live="polite">
+          <div>
+            <dt>Finished pieces with overs</dt>
+            <dd id="runTotalPieces">—</dd>
+          </div>
+          <div>
+            <dt>Press sheets to print</dt>
+            <dd id="runTotalSheets">—</dd>
+          </div>
+          <div>
+            <dt>Overs (pieces / sheets)</dt>
+            <dd id="runOversBreakdown">—</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="data-card summary-calculator" data-calculator="sheets">
+        <header class="summary-calculator__header">
+          <h3 class="summary-calculator__title">Sheets to Pads Converter</h3>
+          <p class="summary-calculator__description">
+            Translate a press run into finished pieces and pad counts.
+          </p>
+        </header>
+        <form class="summary-calculator__form" autocomplete="off">
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">Press sheets to run</span>
+            <input type="number" inputmode="numeric" min="0" step="1" id="sheetRun" placeholder="0" />
+          </label>
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">N-up (per press sheet)</span>
+            <input type="number" inputmode="numeric" min="1" step="1" id="sheetNUp" />
+            <span class="summary-calculator__hint">Auto-fills from the current layout.</span>
+          </label>
+          <label class="summary-calculator__field">
+            <span class="summary-calculator__label">Finished pieces per pad</span>
+            <input type="number" inputmode="numeric" min="1" step="1" id="sheetPerPad" value="50" />
+          </label>
+        </form>
+        <dl class="summary-calculator__results" aria-live="polite">
+          <div>
+            <dt>Total finished pieces</dt>
+            <dd id="sheetTotalPieces">—</dd>
+          </div>
+          <div>
+            <dt>Complete pads</dt>
+            <dd id="sheetTotalPads">—</dd>
+          </div>
+          <div>
+            <dt>Leftover pieces</dt>
+            <dd id="sheetPadRemainder">—</dd>
+          </div>
+        </dl>
+      </article>
+    </div>
+  </section>
 </template>

--- a/docs/js/controllers/layout-updater.js
+++ b/docs/js/controllers/layout-updater.js
@@ -15,6 +15,7 @@ import {
   readNumber,
   resetMeasurementRegistry,
 } from '../utils/dom.js';
+import { updateSummaryCalculators } from './summary-calculators.js';
 import {
   MM_PER_INCH,
   clampToZero,
@@ -145,6 +146,8 @@ export function update() {
 
   updateDocCountField('#forceAcross', layout.counts.across);
   updateDocCountField('#forceDown', layout.counts.down);
+
+  updateSummaryCalculators(layout);
 
   $('#vAcross').textContent = layout.counts.across;
   $('#vDown').textContent = layout.counts.down;

--- a/docs/js/controllers/summary-calculators.js
+++ b/docs/js/controllers/summary-calculators.js
@@ -1,0 +1,249 @@
+import { $, $$ } from '../utils/dom.js';
+
+const numberFormatter = typeof Intl !== 'undefined' ? new Intl.NumberFormat() : { format: (value) => String(value) };
+
+const AUTO_FILL_SELECTORS = ['#padNUp', '#runNUp', '#sheetNUp'];
+const INPUT_SELECTORS = [
+  '#padCount',
+  '#padSheets',
+  '#padNUp',
+  '#runDesired',
+  '#runNUp',
+  '#runOvers',
+  '#sheetRun',
+  '#sheetNUp',
+  '#sheetPerPad',
+];
+
+let isInitialized = false;
+let autoNUp = 1;
+let pendingAutoNUp = null;
+
+const formatNumber = (value) => {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  return numberFormatter.format(value);
+};
+
+const setText = (selector, value) => {
+  const el = $(selector);
+  if (!el) return;
+  el.textContent = value;
+};
+
+const readNumberFromInput = (selector) => {
+  const el = $(selector);
+  if (!el) return Number.NaN;
+  const raw = el.value;
+  if (raw === '') return Number.NaN;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+};
+
+const readInteger = (selector, { min = 0, fallback = 0 } = {}) => {
+  const parsed = readNumberFromInput(selector);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  const floored = Math.floor(parsed);
+  return Math.max(min, floored);
+};
+
+const readFloat = (selector, { min = 0, fallback = 0 } = {}) => {
+  const parsed = readNumberFromInput(selector);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.max(min, parsed);
+};
+
+const readNUp = (selector) => {
+  const value = readInteger(selector, { min: 0, fallback: autoNUp });
+  if (value > 0) {
+    return value;
+  }
+  return autoNUp > 0 ? autoNUp : 0;
+};
+
+const syncAutoFillInputs = () => {
+  AUTO_FILL_SELECTORS.forEach((selector) => {
+    const input = $(selector);
+    if (!input) return;
+    if (input.dataset.autofill === 'false') {
+      return;
+    }
+    input.dataset.autofill = 'true';
+    input.value = autoNUp > 0 ? String(autoNUp) : '';
+  });
+};
+
+const markManualIfUserEdited = (event) => {
+  const target = event.target;
+  if (!target || !AUTO_FILL_SELECTORS.includes(`#${target.id}`)) {
+    return;
+  }
+  target.dataset.autofill = 'false';
+};
+
+const formatPiecesWithSheets = (pieces, sheets) => {
+  if (pieces <= 0 && sheets <= 0) {
+    return 'None';
+  }
+  const parts = [];
+  if (pieces > 0) {
+    parts.push(`${formatNumber(pieces)} pieces`);
+  }
+  if (sheets > 0) {
+    parts.push(`${formatNumber(sheets)} sheets`);
+  }
+  return parts.join(' / ');
+};
+
+const updatePadCalculator = () => {
+  const padCount = readInteger('#padCount', { min: 0, fallback: 0 });
+  const sheetsPerPad = readInteger('#padSheets', { min: 0, fallback: 0 });
+  const nUp = readNUp('#padNUp');
+  if (padCount <= 0 || sheetsPerPad <= 0 || nUp <= 0) {
+    setText('#padTotalPieces', '—');
+    setText('#padTotalSheets', '—');
+    setText('#padRemainder', '—');
+    return;
+  }
+
+  const totalPieces = padCount * sheetsPerPad;
+  const totalSheets = Math.ceil(totalPieces / nUp);
+  const overagePieces = Math.max(0, totalSheets * nUp - totalPieces);
+
+  setText('#padTotalPieces', formatNumber(totalPieces));
+  setText('#padTotalSheets', formatNumber(totalSheets));
+  setText('#padRemainder', overagePieces > 0 ? `${formatNumber(overagePieces)} pieces` : 'None');
+};
+
+const updateRunPlanner = () => {
+  const desiredPieces = readInteger('#runDesired', { min: 0, fallback: 0 });
+  const nUp = readNUp('#runNUp');
+  const oversPercent = readFloat('#runOvers', { min: 0, fallback: 0 });
+
+  if (desiredPieces <= 0 || nUp <= 0) {
+    setText('#runTotalPieces', '—');
+    setText('#runTotalSheets', '—');
+    setText('#runOversBreakdown', '—');
+    return;
+  }
+
+  const oversPieces = Math.ceil((desiredPieces * oversPercent) / 100);
+  const totalPieces = desiredPieces + oversPieces;
+  const baseSheets = Math.ceil(desiredPieces / nUp);
+  const totalSheets = Math.ceil(totalPieces / nUp);
+  const oversSheets = Math.max(0, totalSheets - baseSheets);
+
+  setText('#runTotalPieces', formatNumber(totalPieces));
+  setText('#runTotalSheets', formatNumber(totalSheets));
+  setText('#runOversBreakdown', formatPiecesWithSheets(oversPieces, oversSheets));
+};
+
+const updateSheetsConverter = () => {
+  const sheetsToRun = readInteger('#sheetRun', { min: 0, fallback: 0 });
+  const nUp = readNUp('#sheetNUp');
+  const piecesPerPad = readInteger('#sheetPerPad', { min: 0, fallback: 0 });
+
+  if (sheetsToRun <= 0 || nUp <= 0) {
+    setText('#sheetTotalPieces', '—');
+    setText('#sheetTotalPads', '—');
+    setText('#sheetPadRemainder', '—');
+    return;
+  }
+
+  const totalPieces = sheetsToRun * nUp;
+  const completePads = piecesPerPad > 0 ? Math.floor(totalPieces / piecesPerPad) : 0;
+  const remainderPieces = piecesPerPad > 0 ? totalPieces % piecesPerPad : totalPieces;
+
+  setText('#sheetTotalPieces', formatNumber(totalPieces));
+  setText('#sheetTotalPads', piecesPerPad > 0 ? formatNumber(completePads) : '—');
+  if (piecesPerPad > 0) {
+    setText('#sheetPadRemainder', remainderPieces > 0 ? `${formatNumber(remainderPieces)} pieces` : 'None');
+  } else {
+    setText('#sheetPadRemainder', '—');
+  }
+};
+
+const recalcAll = () => {
+  updatePadCalculator();
+  updateRunPlanner();
+  updateSheetsConverter();
+};
+
+function attachEventListeners() {
+  INPUT_SELECTORS.forEach((selector) => {
+    const input = $(selector);
+    if (!input) return;
+    if (AUTO_FILL_SELECTORS.includes(selector) && !input.dataset.autofill) {
+      input.dataset.autofill = 'true';
+    }
+    input.addEventListener('input', (event) => {
+      markManualIfUserEdited(event);
+      recalcAll();
+    });
+    input.addEventListener('change', (event) => {
+      markManualIfUserEdited(event);
+      recalcAll();
+    });
+  });
+
+  $$('.summary-calculator__form').forEach((form) => {
+    form.addEventListener('submit', (event) => event.preventDefault());
+  });
+}
+
+function ensureDefaultValues() {
+  const defaultPairs = [
+    ['#padSheets', 50],
+    ['#sheetPerPad', 50],
+  ];
+  defaultPairs.forEach(([selector, defaultValue]) => {
+    const input = $(selector);
+    if (!input) return;
+    if (!input.value || Number.isNaN(Number(input.value))) {
+      input.value = String(defaultValue);
+    }
+  });
+}
+
+function applyAutoNUp(nextNUp) {
+  const sanitized = Number.isFinite(nextNUp) ? Math.max(0, Math.floor(nextNUp)) : 0;
+  autoNUp = sanitized;
+  if (!isInitialized) {
+    pendingAutoNUp = autoNUp;
+    return;
+  }
+  syncAutoFillInputs();
+  recalcAll();
+}
+
+export function initializeSummaryCalculators() {
+  if (isInitialized) {
+    return;
+  }
+  isInitialized = true;
+  attachEventListeners();
+  ensureDefaultValues();
+  syncAutoFillInputs();
+  if (pendingAutoNUp !== null) {
+    autoNUp = pendingAutoNUp;
+    syncAutoFillInputs();
+    pendingAutoNUp = null;
+  }
+  recalcAll();
+}
+
+export function updateSummaryCalculators(layout) {
+  const counts = layout?.counts;
+  const totalNUp = Number.isFinite(counts?.across) && Number.isFinite(counts?.down)
+    ? counts.across * counts.down
+    : null;
+  if (totalNUp === null) {
+    return;
+  }
+  applyAutoNUp(totalNUp);
+}

--- a/docs/js/tabs/summary.js
+++ b/docs/js/tabs/summary.js
@@ -1,4 +1,5 @@
 import { $$, getLayerVisibility, setLayerVisibility, applyLayerVisibility } from '../utils/dom.js';
+import { initializeSummaryCalculators } from '../controllers/summary-calculators.js';
 import { hydrateTabPanel } from './registry.js';
 
 let initialized = false;
@@ -6,6 +7,7 @@ const TAB_KEY = 'summary';
 
 function init() {
   hydrateTabPanel(TAB_KEY);
+  initializeSummaryCalculators();
   if (initialized) return;
   $$('.layer-visibility-toggle-input').forEach((input) => {
     const layer = input.dataset.layer;


### PR DESCRIPTION
## Summary
- restyle the summary metrics into cards and add a calculator grid with pad, target quantity, and sheet-to-pad tools
- implement a summary calculator controller that auto-fills layout N-up values and keeps results updated as inputs change
- hook the calculators into the layout updater so they stay in sync with the current layout selections

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690d10dd3e008324a1b60a8be0f67d22