### PR TITLE
Refactor styles to modular brand system

### DIFF
--- a/brand-guidelines.md
+++ b/brand-guidelines.md
@@ -1,220 +1,163 @@
-# Kev’s Bitchin’ Print Calculator  
-### Brand Guidelines
+# Kev’s Bitchin’ Print Calculator
 
-<!--
-Context:
-This document defines the visual language and token system for Kev’s Bitchin’ Print Calculator.
-It standardizes colors, spacing, typography, and component naming so Codex or contributors can maintain visual consistency.
-The palette is inspired by print-production logic — clear contrast, legible metrics, and cyan/magenta/black cues familiar in prepress environments.
--->
+## Brand Guidelines
+
+These notes describe the unified UI system now in use across the calculator. Reference them when introducing new components or updating existing templates.
 
 ---
 
-## 🎨 1. Color System
+## 🎨 Color Palette
 
-<!--
-Purpose:
-Colors are designed for readability in dark environments (like print shops) and to reflect prepress conventions:
-- Cyan = layout guides
-- Magenta/Purple = score/perf lines
-- Red = cut/trim
-- Orange = safety zones
--->
+| Token | Intent | Hex |
+|-------|--------|-----|
+| `--color-surface-0` | App background | `#0f1115` |
+| `--color-surface-1` | Panels & cards | `#171a21` |
+| `--color-surface-2` | Elevated controls | `#1a1f2a` |
+| `--color-surface-3` | Overlays / stage chrome | `#11141b` |
+| `--color-border` | Default border | `#222632` |
+| `--color-border-strong` | Structural dividers | `#2c3446` |
+| `--color-border-accent` | Focus & hover outline | `#1f8a8a` |
+| `--color-accent` | Interactive accent | `#5eead4` |
+| `--color-text-primary` | Primary text | `#e6e9ef` |
+| `--color-text-secondary` | Secondary copy | `#b8c0cc` |
+| `--color-text-muted` | Helper copy | `#8892a6` |
+| `--color-success` | Positive state | `#22c55e` |
+| `--color-warning` | Warning tone | `#f59e0b` |
+| `--color-danger` | Destructive state | `#ef4444` |
+| `--color-paper` | Print background | `#ffffff` |
 
-| Token | Role | Description | Hex | Notes |
-|-------|------|--------------|------|-------|
-| `--color-surface-0` | Background | Deep neutral background | `#0f1115` | Almost black, easy on eyes in dim rooms |
-| `--color-surface-1` | Panel / Card | Slightly lighter than background | `#171a21` | Creates depth for cards and panels |
-| `--color-surface-2` | Overlay / Elevated | Used for toolbars and modals | `#1a1f2a` | Subtle contrast from panels |
-| `--color-border` | Neutral divider | For outlines, frames, and separators | `#222632` | Matches print-trim line tone |
-| `--color-accent` | Accent / Focus | Used for highlights and hover | `#5eead4` | Teal/cyan, evokes press calibration blues |
-| `--color-text-primary` | Main text | Default body color | `#e6e9ef` | Off-white, avoids harsh contrast |
-| `--color-text-secondary` | Secondary text | Labels, helper text | `#b8c0cc` | Mid-gray for hierarchy |
-| `--color-success` | Positive | Success or OK status | `#22c55e` | Vivid green, proof approval cue |
-| `--color-warning` | Warning | Alerts, cautions | `#f59e0b` | Warm amber for visual pop |
-| `--color-danger` | Error | Destructive or invalid state | `#ef4444` | Bright red for failures or deletions |
-
-**Usage Guidelines**
-- Dark mode by default — use `--color-surface-0` and `--color-surface-1` for depth.
-- For print previews, invert text to black on white (`--color-paper: #ffffff;`).
-- Avoid hex codes in components. Always reference tokens.
+Visualizer accents reuse dedicated tokens such as `--viz-line-cut`, `--viz-line-score`, and `--viz-layer-selected` so SVG rendering stays consistent with the UI theme.
 
 ---
 
-## 🧱 2. Spacing Scale
+## ✍️ Typography
 
-<!--
-Purpose:
-Spacing maintains a rhythm across components.
-The 4px base unit mirrors print design grid precision.
--->
+* Font stack: `system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif`
+* Base size / line height: `var(--font-md)` / `var(--line-height-base)`
+* Scale tokens: `--font-xs` (0.8rem), `--font-sm` (0.9rem), `--font-md` (1rem), `--font-lg` (1.25rem), `--font-xl` (1.5rem)
+* Heading weight: 600+; body copy 400.
 
-| Token | Value | Use Case |
-|--------|--------|----------|
-| `--space-1` | 4px | Hairline spacing, icon gaps |
-| `--space-2` | 8px | Compact padding (buttons, labels) |
-| `--space-3` | 12px | Default grid gap |
-| `--space-4` | 16px | Card padding, stack gaps |
-| `--space-5` | 24px | Section padding |
-| `--space-6` | 32px | Page margins, full layout spacing |
-
-**Rules**
-- Use `.gap-sm`, `.gap-md`, `.gap-lg` utilities built from these tokens.
-- Avoid hard-coded margins; rely on standardized space tokens.
+Use `.text-muted`, `.text-secondary`, and `.text-metric` utilities to express hierarchy, captions, and tabular numerics.
 
 ---
 
-## ✍️ 3. Typography
+## 📏 Spatial System
 
-<!--
-Purpose:
-The typography mirrors production documentation — clear, readable, system-native fonts.
-No branding flourishes, no webfonts, just functional, universally available families.
--->
+* Spacing tokens: `--space-1` (4px) through `--space-6` (32px)
+* Radii: `--radius-sm` (6px), `--radius-md` (10px), `--radius-lg` (14px)
+* Shadows: `--shadow-sm` and `--shadow-lg`
+* Motion: `--motion-fast` (150ms), `--motion-slow` (300ms)
 
-| Token | Size | Weight | Role |
-|--------|------|--------|------|
-| `--font-xs` | 0.8rem | 400 | Footnotes, metadata |
-| `--font-sm` | 0.9rem | 400 | Labels, secondary info |
-| `--font-md` | 1rem | 400 | Default body text |
-| `--font-lg` | 1.25rem | 600 | Section headings |
-| `--font-xl` | 1.5rem | 700 | App titles |
+### Utilities
 
-**Font Family**
-```
-system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif
-```
-- Matches platform defaults for native clarity.
-- Resembles UI text seen in production software (Adobe, RIP utilities).
-- Line height: `1.45` for legibility in dense panels.
+* `.layout-stack` + `data-gap="tight|snug|cozy|relaxed|spacious"`
+* `.layout-grid` + `data-cols` / `data-min` for responsive grids
+* `.layout-cluster` for inline groupings with optional `data-align`
+* `.pad-*`, `.gap-*`, `.radius-*`, `.shadow-*` for quick tweaks
+* `.layout-panel` and `.layout-card` standardize chrome across the app.
 
 ---
 
-## 🧩 4. Radius, Shadow & Motion
+## 🧩 Components
 
-<!--
-Purpose:
-Subtle shadows and radii emulate layered paper stacks — tactile but restrained.
--->
+### Buttons
 
-| Token | Value | Use |
-|--------|--------|-----|
-| `--radius-sm` | 6px | Inputs, small buttons |
-| `--radius-md` | 10px | Cards, modals |
-| `--radius-lg` | 14px | Panels, containers |
-| `--shadow-sm` | `0 2px 4px rgba(0,0,0,0.3)` | Subtle inset depth |
-| `--shadow-lg` | `0 12px 24px rgba(0,0,0,0.4)` | Elevated overlays |
-| `--motion-fast` | 150ms | Hover or tap transitions |
-| `--motion-slow` | 300ms | Panel expansion, modals |
-
----
-
-## 🧱 5. Component Naming System
-
-<!--
-Purpose:
-Classes should describe what something *is*, not how it’s laid out.
-Prefixes group components by domain: layout, form, button, visualizer, etc.
--->
-
-| Component | Old Class | New Class | Purpose |
-|------------|------------|-----------|----------|
-| App Shell | `.layout-app-shell` | `.layout-shell` | Main wrapper container |
-| Header | `.layout-app-header` | `.layout-header` | Title area |
-| Input Grid | `.input-2col-grid` | `.form-grid--dual` | Two-column form group |
-| Swap Button | `.input-swap-button` | `.btn-swap` | Swap control button |
-| Action Button | `.action-button-primary` | `.btn-primary` | Main action |
-| Sheet Preview | `.sheet-preview-stage` | `.viz-stage` | Layout visualizer |
-| Visibility Panel | `.layer-visibility-panel` | `.viz-layers` | Layer toggles |
-| Summary Section | `.summary-calculator-section` | `.summary-section` | Output summary panel |
-
-**Prefix Convention**
-- `layout-` = structure  
-- `form-` = inputs and controls  
-- `btn-` = button styles  
-- `viz-` = visualization elements  
-- `summary-` = output and reporting  
-
----
-
-## 🧮 6. Utility Classes
-
-<!--
-Purpose:
-Lightweight utilities replace one-off declarations, making markup easier to compose.
--->
-
-| Utility | Function |
-|----------|-----------|
-| `.layout-stack[data-gap="snug"]` | Vertical flex stack with adjustable spacing |
-| `.layout-grid[data-cols="2"]` | Responsive grid with 2 columns |
-| `.pad-sm`, `.pad-md`, `.pad-lg` | Padding utilities (use space tokens) |
-| `.gap-sm`, `.gap-md`, `.gap-lg` | Gap utilities |
-| `.text-muted`, `.text-secondary` | Text hierarchy helpers |
-| `.radius-md`, `.shadow-lg` | Border radius and elevation helpers |
-
----
-
-## 🖨️ 7. Print Mode
-
-<!--
-Purpose:
-When printing a layout summary or measurement sheet, UI chrome should be hidden.
-Maintain color and spacing but switch to light theme.
--->
-
-**Rules**
-- Background → `--color-paper: #ffffff`
-- Text → `--color-text-inverse: #000000`
-- Hide `.is-interactive`, `.print-hidden`
-- Remove shadows and borders for accurate print dimensions.
-
----
-
-## 📘 8. Example Component Usage
-
-#### Button
 ```html
-<button class="btn-primary">Calculate Layout</button>
+<button class="btn">Default</button>
+<button class="btn btn-primary">Primary</button>
+<button class="btn btn-ghost">Ghost</button>
+<button class="btn btn-swap" aria-label="Swap">↔︎</button>
 ```
 
-#### Form Input
+### Form Controls
+
 ```html
 <label class="form-label">
-  Sheet Width
-  <input class="form-control" type="number" value="12">
+  <span>Label</span>
+  <input class="form-control" type="number" />
+</label>
+
+<select class="form-select">
+  <option>Option</option>
+</select>
+
+<label class="form-choice">
+  <input class="form-choice__control" type="checkbox" checked />
+  <span class="form-choice__label">Printable layer</span>
 </label>
 ```
 
-#### Visualizer
+`form-grid--dual`, `form-row[data-cols]`, `form-toolbar`, and `.form-choice` cover the majority of calculator inputs without bespoke CSS.
+
+### Visualizer
+
 ```html
-<section class="viz-stage">
-  <svg class="viz-canvas"></svg>
+<section class="layout-panel viz-shell layout-stack" data-gap="cozy">
+  <div class="viz-layout">
+    <div class="viz-stage viz-theme"><svg id="svg"></svg></div>
+    <aside class="viz-layers">
+      <label class="viz-layer-toggle">
+        <input class="viz-layer-input" type="checkbox" data-layer="layout" checked />
+        <span class="viz-layer-label">
+          <i class="viz-legend-swatch" data-layer="layout"></i>
+          Layout Area
+        </span>
+      </label>
+    </aside>
+  </div>
 </section>
+```
+
+### Summary Cards
+
+```html
+<article class="layout-card summary-card">
+  <h3>Counts</h3>
+  <dl class="summary-metrics">
+    <div><dt>Across</dt><dd class="text-metric">12</dd></div>
+    <div><dt>Down</dt><dd class="text-metric">18</dd></div>
+  </dl>
+</article>
 ```
 
 ---
 
-## ⚙️ 9. Migration Map
+## 🔄 Migration Map
 
-<!--
-Purpose:
-Links old class names to the new semantic system for easy find-and-replace.
--->
-
-| Old Class | New Class |
-|------------|-----------|
+| Old Class | New Class / Pattern |
+|-----------|---------------------|
+| `.layout-app-shell` | `.layout-shell` |
+| `.layout-app-header` | `.layout-header` |
+| `.content-section` | `.layout-panel` |
+| `.data-card` | `.layout-card` |
+| `.stack` | `.layout-stack` + `data-gap` |
+| `.grid`, `.grid--columns-2`, `.grid--auto-fit` | `.layout-grid` + `data-cols` / `data-min` |
+| `.control-toolbar` | `.form-toolbar layout-cluster` |
 | `.input-2col-grid` | `.form-grid--dual` |
+| `.input-field-row(-quad)` | `.form-row` (+ `data-cols="4"` where needed) |
+| `.input-field-action` | `.form-row-actions` |
 | `.action-button` | `.btn` |
-| `.action-button-primary` | `.btn-primary` |
-| `.sheet-preview-visualizer` | `.viz-container` |
-| `.layer-visibility-option` | `.viz-layer-item` |
-| `.summary-calculator-section` | `.summary-section` |
+| `.action-button-primary` | `.btn btn-primary` |
+| `.action-button-ghost` | `.btn btn-ghost` |
+| `.input-swap-button` | `.btn btn-swap` |
+| `.sheet-preview-stage` | `.viz-stage` |
+| `.layer-visibility-panel` | `.viz-layers` |
+| `.layer-visibility-option` | `.viz-layer-toggle` |
+| `.layer-visibility-toggle-input` | `.viz-layer-input` |
+| `.sheet-preview-visualizer` | `.viz-shell` |
+| `.measurement-row` | `.viz-measure-row` |
+| `.output-tab-navigation` | `.tabs-nav` |
+| `.output-tab-trigger` | `.tabs-trigger` |
+| `.output-tabpanel-collection` | `.tabs-panels` |
+| `.print-layer-panel` | `fieldset.layout-card.layout-stack` |
+| `.print-layer-option` | `.form-choice` + `.print-layer-toggle` |
+
+When migrating markup, prefer the utility-first structure shown above and remove obsolete modifiers (e.g., `stack--snug`).
 
 ---
 
-<!--
-End Notes:
-This brand system keeps the dark, production-ready feel of the current app but cuts redundancy.
-All future UI additions (e.g., hole drilling, scoring tabs) should extend from these tokens and naming patterns.
--->
+## 🧾 Notes
+
+* All color, spacing, and typography values are centralized in `docs/css/tokens.css`.
+* Responsive adjustments lean on fluid grids and gap utilities; avoid bespoke media queries unless a layout truly requires them.
+* The print experience uses `.print-stage` with `.form-choice` toggles—visibility still respects `.print-hidden` / `.print-only` helpers.

--- a/docs/css/celebration.css
+++ b/docs/css/celebration.css
@@ -14,7 +14,7 @@
   height: auto;
   z-index: 9999;
   pointer-events: none;
-  filter: drop-shadow(0 14px 18px color-mix(in srgb, var(--text-inverse) 55%, transparent));
+  filter: drop-shadow(0 14px 18px color-mix(in srgb, var(--color-text-inverse) 55%, transparent));
   animation: freedom-eagle-flight 4s cubic-bezier(0.32, 0.64, 0.45, 1) forwards;
   will-change: transform, opacity;
 }
@@ -45,13 +45,13 @@
   z-index: 9999;
   padding: 12px 20px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--surface-bg) 88%, transparent);
-  color: var(--text-primary);
+  background: color-mix(in srgb, var(--color-surface-0) 88%, transparent);
+  color: var(--color-text-primary);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  border: 2px solid color-mix(in srgb, var(--text-muted) 40%, transparent);
-  box-shadow: 0 14px 30px color-mix(in srgb, var(--text-inverse) 35%, transparent);
+  border: 2px solid color-mix(in srgb, var(--color-text-muted) 40%, transparent);
+  box-shadow: 0 14px 30px color-mix(in srgb, var(--color-text-inverse) 35%, transparent);
   pointer-events: none;
   animation: freedom-alert-fade 3.5s ease-in-out forwards;
 }

--- a/docs/css/controls.css
+++ b/docs/css/controls.css
@@ -1,271 +1,225 @@
 /* =============================================
- * Controls & Navigation
+ * Forms & Controls
  * ---------------------------------------------
- * Shared control chrome, buttons, form inputs,
- * typography helpers, and navigation patterns.
+ * Shared styles for labels, inputs, tab triggers,
+ * and button variants across the interface.
  * ============================================= */
-.text-muted-detail { color: var(--text-muted); }
-.text-metric-readout { font-variant-numeric: tabular-nums; }
-
-:is(.control-base,
-    label input,
-    select,
-    .action-button,
-    .input-swap-button) {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  font: inherit;
-  color: var(--control-color, var(--text-primary));
-  background: var(--control-bg, var(--surface-control));
-  border: 1px solid var(--control-border, var(--border-strong));
-  border-radius: 8px;
-  padding: var(--control-padding, 6px 8px);
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-:is(.control-base,
-    label input,
-    select,
-    .action-button,
-    .input-swap-button):hover,
-:is(.control-base,
-    label input,
-    select,
-    .action-button,
-    .input-swap-button):focus {
-  background: var(--control-bg-hover, var(--surface-control-hover));
-  border-color: var(--control-border-hover, var(--border-accent));
-}
-
-:is(.control-base,
-    label input,
-    select,
-    .action-button,
-    .input-swap-button):focus-visible {
-  outline: 2px solid var(--accent-focus-ring);
-  outline-offset: 2px;
-}
-
-label {
+.form-label {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 6px;
-  padding: 4px 6px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  transition: border-color var(--motion-fast) ease, background var(--motion-fast) ease;
+}
+
+.form-label span { font-size: var(--font-sm); color: var(--color-text-muted); }
+
+.form-label:hover { border-color: var(--color-border); }
+
+.form-control,
+.form-select {
+  appearance: none;
+  font: inherit;
+  color: var(--color-text-primary);
+  background: var(--color-surface-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  min-height: 36px;
+  transition: border-color var(--motion-fast) ease, background var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+}
+
+.form-control:focus-visible,
+.form-select:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+
+.form-label .form-control,
+.form-label .form-select {
+  border: none;
   background: transparent;
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
-}
-
-label span { color: var(--text-muted); font-size: 0.9rem; }
-
-label input {
-  all: unset;
-  display: inline-block;
-  width: 96px;
-  text-align: right;
-  color: var(--text-primary);
-  background: var(--surface-panel-elevated);
-}
-
-label input:focus-visible { outline-offset: 0; }
-
-select { display: inline-block; width: 100%; background: var(--surface-panel-elevated); }
-
-.input-2col-grid label,
-.layer-visibility-option .layer-visibility-label { border-radius: 10px; }
-
-.input-2col-grid label { gap: 10px; padding: 4px 10px; border-width: 1px; }
-.input-2col-grid label span { font-size: 0.85rem; }
-
-.input-2col-grid label input,
-.input-2col-grid select {
+  color: var(--color-text-primary);
+  padding: 0;
+  min-height: auto;
   width: 100%;
-  border-radius: 10px;
+  text-align: right;
 }
 
-.input-swap-button {
-  --control-padding: 0;
-  --control-bg: var(--surface-control);
-  --control-border: var(--border-subtle);
-  --control-bg-hover: var(--surface-control-hover);
-  border-radius: 999px;
+input[type="number"].form-control { text-align: right; }
+
+.form-grid--dual {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.form-section {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.form-section > h2 { font-size: var(--font-sm); font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; color: var(--color-text-secondary); }
+
+.form-row {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.form-row[data-cols="4"] { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+
+.form-row[data-variant="with-action"] {
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
+  align-items: end;
+}
+
+.form-row-actions { display: flex; align-items: center; justify-content: center; }
+
+/* ---- Choice chips ---- */
+.form-choice {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-2);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: border-color var(--motion-fast) ease, background var(--motion-fast) ease,
+    color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+}
+
+.form-choice:hover { border-color: var(--color-border); color: var(--color-text-primary); }
+
+.form-choice__control { margin: 0; accent-color: var(--color-accent); }
+
+.form-choice__label { font-size: var(--font-sm); color: inherit; }
+
+.form-choice:has(.form-choice__control:checked) {
+  border-color: var(--color-border-accent);
+  background: color-mix(in srgb, var(--color-accent) 16%, var(--color-surface-2));
+  color: var(--color-text-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 40%, transparent);
+}
+
+.form-choice:has(.form-choice__control:checked) .form-choice__label {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.form-choice:has(.form-choice__control:focus-visible) {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.form-toolbar { padding: 0; }
+.form-toolbar.layout-sticky { background: var(--color-surface-1); border-bottom: 1px solid var(--color-border); }
+
+.form-status { font-size: var(--font-sm); color: var(--color-text-secondary); }
+
+/* ---- Buttons ---- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  font: inherit;
+  color: var(--color-text-primary);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease, color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  background: color-mix(in srgb, var(--color-surface-2) 70%, var(--color-accent) 30%);
+  border-color: var(--color-accent);
+}
+
+.btn:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+
+.btn:disabled,
+.btn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.btn-primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #062521;
+  box-shadow: 0 6px 18px rgba(94, 234, 212, 0.25);
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  background: color-mix(in srgb, var(--color-accent) 85%, white 15%);
+  color: #031714;
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-text-secondary);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus-visible {
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+  border-color: var(--color-accent);
+  color: var(--color-text-primary);
+}
+
+.btn-swap {
   inline-size: 32px;
   block-size: 32px;
-  cursor: pointer;
+  border-radius: 999px;
+  padding: 0;
+  font-size: 1rem;
 }
 
-.input-swap-button:focus-visible { box-shadow: 0 0 0 3px var(--accent-focus-ring); }
-
-.nav-bar {
-  display: flex;
-  align-items: stretch;
-  gap: var(--nav-gap, 8px);
-  padding: var(--nav-padding, 0);
-  border-bottom: var(--nav-border-size, 0px) solid var(--nav-border-color, transparent);
+/* ---- Tabs ---- */
+.tabs-nav {
+  border-bottom: 1px solid var(--color-border);
+  padding-inline: var(--space-3);
 }
 
-.nav-bar--tabs {
-  --nav-gap: 6px;
-  --nav-padding: 0 10px;
-  --nav-border-size: 1px;
-  --nav-border-color: var(--border-default);
-}
-
-.nav-trigger {
+.tabs-trigger {
   appearance: none;
   background: none;
   border: none;
-  border-bottom: var(--nav-trigger-border-width, 2px) solid transparent;
-  color: var(--nav-text-muted, var(--text-secondary));
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-secondary);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
+  gap: var(--space-2);
   font: inherit;
   font-weight: 500;
-  gap: 6px;
-  line-height: 1.2;
-  padding: var(--nav-trigger-padding, 8px 12px);
-  transition: color 0.18s ease, border-color 0.18s ease;
+  padding: var(--space-2) var(--space-3);
+  transition: color var(--motion-fast) ease, border-color var(--motion-fast) ease;
 }
 
-.nav-trigger--tab {
-  --nav-trigger-padding: 10px 12px;
-  --nav-trigger-border-width: 2px;
-}
+.tabs-trigger:hover { color: var(--color-accent); }
 
-.nav-trigger:hover { color: var(--accent-primary); }
-
-.nav-trigger:focus-visible {
-  outline: 2px solid var(--border-accent);
+.tabs-trigger:focus-visible {
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
-.nav-trigger.is-active {
-  color: var(--text-primary);
-  border-bottom-color: var(--accent-primary);
+.tabs-trigger.is-active {
+  color: var(--color-text-primary);
+  border-bottom-color: var(--color-accent);
 }
 
-.output-tab-navigation { margin: 0 -14px 10px; }
-.output-tabpanel-collection > section { display: none; }
-.output-tabpanel-collection > section.is-active { display: block; }
-
-.action-button {
-  --control-padding: 8px 10px;
-  --control-bg: var(--surface-control);
-  --control-border: var(--border-muted);
-  --control-bg-hover: var(--surface-inset);
-  --control-border-hover: var(--border-accent);
-  border-radius: 10px;
-  cursor: pointer;
-}
-
-.action-button-primary { --control-border: var(--border-accent); }
-
-.action-button-ghost {
-  --control-bg: transparent;
-  --control-border: transparent;
-}
-
-.action-button.is-active {
-  --control-bg: var(--accent-surface-tint);
-  color: var(--accent-primary);
-  border-color: var(--accent-primary);
-}
-
-.action-button:focus-visible { outline-color: var(--accent-primary); }
-
-.control-toolbar { display: flex; gap: 8px; }
-
-.layer-visibility-option {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  border-radius: 10px;
-  cursor: pointer;
-}
-
-.layer-visibility-option .layer-visibility-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex: 1;
-  padding: 8px 10px;
-  border: 1px solid var(--border-overlay);
-  background: var(--surface-control);
-  color: var(--text-muted);
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.layer-visibility-option .layer-visibility-label .legend-color-swatch { flex-shrink: 0; }
-
-.layer-visibility-option:hover .layer-visibility-label {
-  border-color: var(--border-accent);
-  background: var(--surface-control-hover);
-  color: var(--text-secondary);
-}
-
-.layer-visibility-option input[type="checkbox"] {
-  appearance: none;
-  width: 18px;
-  height: 18px;
-  border-radius: 6px;
-  border: 1px solid var(--border-overlay);
-  background: var(--surface-control);
-  display: grid;
-  place-items: center;
-  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-  cursor: pointer;
-}
-
-.layer-visibility-option input[type="checkbox"]::after {
-  content: "";
-  width: 8px;
-  height: 12px;
-  border: 2px solid var(--surface-panel);
-  border-top: 0;
-  border-left: 0;
-  transform: rotate(45deg) scale(0);
-  transform-origin: center;
-  transition: transform 0.18s ease;
-}
-
-.layer-visibility-option input[type="checkbox"]:focus-visible {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
-}
-
-.layer-visibility-option input[type="checkbox"]:checked {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
-  box-shadow: 0 0 0 1px var(--accent-focus-ring);
-}
-
-.layer-visibility-option input[type="checkbox"]:checked::after { transform: rotate(45deg) scale(1); }
-
-.layer-visibility-option input[type="checkbox"]:checked + .layer-visibility-label {
-  border-color: color-mix(in srgb, var(--accent-primary) 60%, var(--border-overlay));
-  background: var(--accent-surface-tint);
-  color: var(--text-primary);
-  box-shadow: 0 0 0 1px var(--accent-surface-veil);
-}
-
-.layer-visibility-option input[type="checkbox"]:checked + .layer-visibility-label span { color: inherit; }
-
-.legend-color-swatch {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  border-radius: 3px;
-  margin-right: 6px;
-}
-
-.print-actions { display: grid; gap: 12px; }
-.print-action-row { display: flex; flex-wrap: wrap; gap: 12px; }
-.print-actions-hint { margin: 0; font-size: 0.85rem; }
+.tabs-panels > section { display: none; }
+.tabs-panels > section.is-active { display: block; }

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -1,8 +1,8 @@
 /* =============================================
- * Layout & Structure
+ * Layout & Foundations
  * ---------------------------------------------
- * Base resets, typography, spacing utilities,
- * responsive layout containers, and shell chrome.
+ * Base reset, typography, structural utilities,
+ * and shell containers shared across the app.
  * ============================================= */
 * { box-sizing: border-box; }
 
@@ -11,266 +11,188 @@ body { height: 100%; }
 
 body {
   margin: 0;
-  background: var(--surface-bg);
-  color: var(--text-primary);
-  font: 14px/1.45 system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  background: var(--color-surface-0);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-md);
+  line-height: var(--line-height-base);
 }
+
+a { color: var(--color-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
 
 h1,
 h2,
-h3 { margin: 0 0 0.5rem; }
+h3,
+h4 { margin: 0 0 var(--space-2); font-weight: 600; color: var(--color-text-primary); }
 
-h1 { font-size: 1.25rem; text-align: center; }
-h2 { font-size: 1.05rem; color: var(--text-secondary); }
-h3 { font-size: 0.95rem; color: var(--text-secondary); }
+h1 { font-size: var(--font-lg); text-align: center; }
+h2 { font-size: 1.05rem; color: var(--color-text-secondary); }
+h3 { font-size: 0.95rem; color: var(--color-text-secondary); }
 
-.stack {
+p { margin: 0 0 var(--space-3); }
+
+svg { display: block; max-width: 100%; height: auto; }
+
+table { width: 100%; border-collapse: collapse; }
+
+td,
+th { padding: var(--space-2) var(--space-3); border-bottom: 1px dashed var(--color-border-muted); text-align: left; }
+
+th { color: var(--color-text-secondary); font-weight: 500; letter-spacing: 0.02em; }
+
+/* ---- Shell containers ---- */
+.layout-shell {
+  margin: 0 auto;
+  min-height: 100vh;
+  max-width: var(--layout-max-width);
+  padding: var(--space-6) var(--space-5) var(--space-6);
   display: flex;
   flex-direction: column;
-  gap: var(--gap, var(--gap-default));
+  gap: var(--space-5);
 }
 
-.stack--compact { --gap: var(--gap-tight); }
-.stack--snug { --gap: var(--gap-snug); }
-.stack--roomy { --gap: var(--gap-roomy); }
-.stack--spacious { --gap: var(--gap-spacious); }
+.layout-header { max-width: 720px; margin: 0 auto; }
 
-.grid {
+
+.layout-panel {
+  background: var(--layout-panel-bg, var(--color-surface-1));
+  border: 1px solid var(--layout-panel-border, var(--color-border));
+  border-radius: var(--layout-panel-radius, var(--radius-lg));
+  box-shadow: var(--layout-panel-shadow, 0 8px 28px rgba(0, 0, 0, 0.45));
+  padding: var(--layout-panel-padding, var(--space-4));
+}
+
+.layout-card {
+  background: var(--layout-card-bg, var(--color-surface-1));
+  border: 1px solid var(--layout-card-border, var(--color-border-muted));
+  border-radius: var(--layout-card-radius, var(--radius-md));
+  box-shadow: var(--layout-card-shadow, 0 4px 18px rgba(0, 0, 0, 0.35));
+  padding: var(--layout-card-padding, var(--space-4));
+}
+
+.layout-panel[data-variant="overlay"],
+.layout-card[data-variant="overlay"] {
+  background: var(--color-surface-2);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+}
+
+/* ---- Structural utilities ---- */
+.layout-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap, var(--space-4));
+}
+
+.layout-stack[data-gap="tight"] { --stack-gap: var(--space-1); }
+.layout-stack[data-gap="snug"] { --stack-gap: var(--space-2); }
+.layout-stack[data-gap="cozy"] { --stack-gap: var(--space-3); }
+.layout-stack[data-gap="relaxed"] { --stack-gap: var(--space-5); }
+.layout-stack[data-gap="spacious"] { --stack-gap: var(--space-6); }
+
+.layout-grid {
   display: grid;
-  gap: var(--gap, var(--gap-default));
+  gap: var(--grid-gap, var(--space-4));
+  grid-template-columns: repeat(auto-fit, minmax(var(--grid-min, 240px), 1fr));
 }
 
-.grid--compact { --gap: var(--gap-tight); }
-.grid--snug { --gap: var(--gap-snug); }
-.grid--roomy { --gap: var(--gap-roomy); }
-.grid--spacious { --gap: var(--gap-spacious); }
-.grid--auto-fit { grid-template-columns: repeat(auto-fit, minmax(var(--grid-min, 240px), 1fr)); }
-.grid--auto-fill { grid-template-columns: repeat(auto-fill, minmax(var(--grid-min, 150px), 1fr)); }
-.grid--columns-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.layout-grid[data-gap="tight"] { --grid-gap: var(--space-1); }
+.layout-grid[data-gap="snug"] { --grid-gap: var(--space-2); }
+.layout-grid[data-gap="cozy"] { --grid-gap: var(--space-3); }
+.layout-grid[data-gap="relaxed"] { --grid-gap: var(--space-5); }
 
-.layout-app-shell {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 16px 18px 24px;
-  min-height: 100vh;
-  --gap: var(--gap-spacious);
+.layout-grid[data-cols="2"] { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.layout-grid[data-cols="3"] { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.layout-grid[data-cols="auto"] { grid-template-columns: repeat(auto-fit, minmax(var(--grid-min, 220px), 1fr)); }
+
+.layout-grid[data-min="180"] { --grid-min: 180px; }
+.layout-grid[data-min="220"] { --grid-min: 220px; }
+.layout-grid[data-min="260"] { --grid-min: 260px; }
+.layout-grid[data-min="280"] { --grid-min: 280px; }
+.layout-grid[data-min="340"] { --grid-min: 340px; }
+
+.layout-cluster {
+  display: flex;
+  align-items: center;
+  gap: var(--cluster-gap, var(--space-3));
+  flex-wrap: wrap;
 }
 
-.layout-app-header {
-  padding: 4px 6px 0;
-  --gap: 4px;
-}
+.layout-cluster[data-gap="tight"] { --cluster-gap: var(--space-1); }
+.layout-cluster[data-gap="snug"] { --cluster-gap: var(--space-2); }
+.layout-cluster[data-gap="relaxed"] { --cluster-gap: var(--space-5); }
 
-.layout-app-header p {
-  margin: 0;
-  max-width: 640px;
-}
+.layout-cluster[data-align="start"] { justify-content: flex-start; }
+.layout-cluster[data-align="center"] { justify-content: center; }
+.layout-cluster[data-align="end"] { justify-content: flex-end; }
+.layout-cluster[data-align="between"] { justify-content: space-between; }
 
-.stack .control-toolbar,
-.stack .visualizer-visibility-toggles { margin: 0; }
+.layout-scroll { overflow-y: auto; scrollbar-gutter: stable both-edges; }
 
-.content-section {
-  background: var(--surface-panel);
-  border: 1px solid var(--border-default);
-  border-radius: 14px;
-  padding: 14px;
-  box-shadow: 0 4px 24px var(--shadow-deep);
-}
-
-.sheet-preview-visualizer { --gap: 12px; }
-.output-details-section { --gap: 0; }
-
-.output-details-section .output-tabpanel-collection {
-  flex: 1;
-  min-height: 0;
-}
-
-.sheet-preview-container { --gap: var(--gap-snug); }
-
-.input-scroll-container {
-  flex: 1;
-  min-height: 0;
-  --gap: 16px;
-  overflow-y: auto;
-  padding-right: 6px;
-}
-
-.input-unit-controls {
+.layout-sticky {
   position: sticky;
   top: 0;
-  padding: 6px 0 10px;
-  background: var(--surface-panel);
-  z-index: 1;
-  box-shadow: 0 6px 12px var(--shadow-elevated);
-  margin: 0;
+  z-index: 5;
+  background: inherit;
+  padding-block: var(--space-2);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.45);
 }
 
-.input-unit-controls::after {
-  content: "";
-  position: absolute;
-  inset: auto 0 0;
-  height: 1px;
-  background: var(--border-default);
-  opacity: 0.6;
-}
+.layout-divider { border-bottom: 1px solid var(--color-border-muted); margin-block: var(--space-3); }
 
-.input-2col-grid {
+/* ---- Utilities ---- */
+.pad-sm { padding: var(--space-2); }
+.pad-md { padding: var(--space-4); }
+.pad-lg { padding: var(--space-5); }
+
+.gap-sm { gap: var(--space-2); }
+.gap-md { gap: var(--space-3); }
+.gap-lg { gap: var(--space-5); }
+
+.radius-sm { border-radius: var(--radius-sm); }
+.radius-md { border-radius: var(--radius-md); }
+.radius-lg { border-radius: var(--radius-lg); }
+
+.shadow-sm { box-shadow: var(--shadow-sm); }
+.shadow-lg { box-shadow: var(--shadow-lg); }
+
+.text-muted { color: var(--color-text-muted); }
+.text-secondary { color: var(--color-text-secondary); }
+.text-metric { font-variant-numeric: tabular-nums; }
+
+.print-hidden { display: block; }
+.print-only { display: none; }
+
+/* ---- Summary layout ---- */
+.summary-shell { flex: 1; min-height: 0; }
+
+.summary-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-4);
-  align-items: start;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.input-2col-grid .col-left,
-.input-2col-grid .col-right {
-  display: grid;
-  gap: var(--space-4);
-  align-content: start;
-}
-
-.input-2col-grid .group {
-  display: grid;
-  grid-template-rows: auto auto;
-  row-gap: var(--space-2);
-  padding: 0;
-  border: 0;
-  background: transparent;
-}
-
-.input-2col-grid .group > h2 {
-  font-size: var(--font-sm);
-  font-weight: 600;
-  margin: 0 0 var(--space-1);
-  opacity: 0.9;
-}
-
-.input-2col-grid .control-toolbar { margin: 0; }
-
-.input-field-row,
-.input-field-row-quad {
+.summary-card {
   display: grid;
   gap: var(--space-2);
 }
 
-.input-field-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.summary-metrics { display: grid; gap: var(--space-2); }
+.summary-metrics > div { display: flex; justify-content: space-between; gap: var(--space-2); }
+.summary-metrics dt { margin: 0; color: var(--color-text-secondary); font-weight: 500; }
+.summary-metrics dd { margin: 0; font-weight: 600; text-align: right; font-variant-numeric: tabular-nums; }
 
-.input-field-row.with-action {
-  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
-  align-items: end;
+/* ---- Responsive helpers ---- */
+@media (max-width: 960px) {
+  .layout-shell { padding-inline: var(--space-4); }
+  .layout-grid[data-collapse="md"] { grid-template-columns: 1fr !important; }
+  .layout-cluster[data-align="between"] { justify-content: flex-start; }
 }
 
-.input-field-action {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.input-field-row-quad { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-
-.input-field-row-auto {
-  gap: var(--gap-snug);
-  --grid-min: 150px;
-}
-
-.summary-metrics-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-}
-
-.summary-metric-value { font-variant-numeric: tabular-nums; font-weight: 600; }
-
-.summary-card__metrics { margin: 0; display: grid; gap: 6px; }
-.summary-card__metrics > div { display: flex; justify-content: space-between; gap: 12px; }
-.summary-card__metrics dt { margin: 0; font-weight: 500; color: var(--text-secondary); }
-.summary-card__metrics dd { margin: 0; text-align: right; }
-
-.summary-calculator-section {
-  margin-top: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.summary-calculator-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.summary-calculator__title { margin: 0 0 4px; font-size: 1.1rem; }
-.summary-calculator__description { margin: 0; color: var(--text-secondary); font-size: 0.9rem; }
-.summary-calculator__label { font-weight: 600; }
-.summary-calculator__field input { width: 100%; }
-
-.summary-calculator__form { display: grid; gap: 12px; margin-bottom: 14px; }
-.summary-calculator__field { display: flex; flex-direction: column; gap: 4px; }
-.summary-calculator__results { margin: 0; display: grid; gap: 8px; }
-.summary-calculator__results > div { display: flex; justify-content: space-between; gap: 12px; }
-.summary-calculator__results dt { margin: 0; font-weight: 500; color: var(--text-secondary); }
-.summary-calculator__results dd {
-  margin: 0;
-  font-weight: 600;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
-.data-card {
-  background: var(--surface-card);
-  border: 1px solid var(--border-muted);
-  border-radius: 12px;
-  padding: 12px;
-}
-
-.data-card > .control-toolbar { margin: 0 0 6px; }
-.preset-selector-toolbar { justify-content: flex-start; }
-.input-action-toolbar { justify-content: space-between; gap: 12px; }
-
-.summary-card__title { margin: 0 0 8px; font-size: 1.05rem; }
-
-.data-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.data-table th,
-.data-table td {
-  padding: 8px 10px;
-  border-bottom: 1px dashed var(--border-dashed);
-}
-
-.data-table th {
-  text-align: left;
-  color: var(--text-secondary);
-}
-
-.summary-calculator__hint { font-size: 0.8rem; color: var(--text-tertiary); }
-
-@media (--bp-laptop) {
-  .input-2col-grid { grid-template-columns: 1fr; }
-  .input-2col-grid .col-left,
-  .input-2col-grid .col-right { gap: var(--space-3); }
-  .input-field-row-quad { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
-
-@media (--bp-mobile) {
-  .input-field-row { grid-template-columns: 1fr 1fr; }
-  .input-field-row-quad { grid-template-columns: 1fr 1fr; }
-  .input-field-row.with-action { grid-template-columns: 1fr 1fr; }
-  .input-field-row.with-action .input-field-action {
-    grid-column: 1 / -1;
-    justify-content: flex-end;
-  }
-}
-
-@media (--bp-tablet) {
-  .input-scroll-container { overflow: visible; padding-right: 0; }
-  .input-unit-controls { position: static; box-shadow: none; }
-  .input-unit-controls::after { display: none; }
-  .sheet-preview-layout { flex-direction: column; }
-  .layer-visibility-panel { width: 100%; max-width: none; }
-}
-
-@media (--bp-desktop) {
-  .print-layout-grid { grid-template-columns: minmax(280px, 340px) minmax(0, 1fr); }
+@media (max-width: 720px) {
+  body { font-size: 0.95rem; }
+  .layout-shell { padding: var(--space-5) var(--space-3); }
+  .layout-panel { padding: var(--space-3); }
+  .layout-card { padding: var(--space-3); }
+  .layout-stack[data-gap="spacious"] { --stack-gap: var(--space-5); }
 }

--- a/docs/css/print.css
+++ b/docs/css/print.css
@@ -1,18 +1,20 @@
 /* =============================================
- * Print & Accessibility Media
+ * Print & Motion Preferences
  * ---------------------------------------------
- * Print-mode adjustments, screen-only toggles,
- * and reduced-motion preferences.
+ * Light theme overrides for hardcopy output and
+ * accessibility tweaks for reduced motion.
  * ============================================= */
 @media print {
-  body { background: var(--surface-paper); color: var(--text-inverse); }
+  body { background: var(--color-paper); color: var(--color-text-inverse); }
   .print-hidden { display: none !important; }
-  .print-only-content { display: block !important; }
-  .content-section { border: none; box-shadow: none; }
-  .layout-app-shell { max-width: none; }
+  .print-only { display: block !important; }
+  .layout-shell { max-width: none; padding: 0; }
+  .layout-panel,
+  .layout-card,
+  .viz-stage,
+  .viz-layers,
+  .print-stage { border: none; box-shadow: none; background: var(--color-paper); color: var(--color-text-inverse); }
 }
-
-.print-only-content { display: none; }
 
 @media (prefers-reduced-motion: reduce) {
   * {

--- a/docs/css/tabs/drilling.css
+++ b/docs/css/tabs/drilling.css
@@ -1,63 +1,48 @@
 /* =============================================
  * Drilling Planner
  * ---------------------------------------------
- * Layout styles for the hole drilling configuration tab.
+ * Custom layouts for configuring hole drilling
+ * presets and ad-hoc locations.
  * ============================================= */
+.drilling-card { display: grid; gap: var(--space-3); }
 
-.drilling-configuration-card { --gap: var(--gap-roomy); }
-
-.drilling-plan-fields {
-  --gap: var(--gap-default);
+.drilling-plan-grid {
+  display: grid;
+  gap: var(--space-3);
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-items: flex-end;
+  align-items: end;
 }
 
-.drilling-plan-fields label select {
-  width: 100%;
-}
+.drilling-plan-grid select { width: 100%; }
 
-.drilling-custom-config > p {
-  margin: 0;
-}
+.drilling-note { margin: 0; }
 
-.drilling-location-list { --gap: var(--gap-default); }
+.drilling-location-list { display: grid; gap: var(--space-3); }
 
 .drilling-location-row {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   align-items: end;
-  padding: 12px;
-  border: 1px solid var(--border-overlay);
-  border-radius: 12px;
-  background: var(--surface-control);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-2);
 }
 
-.drilling-location-row .finishing-score-label span {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
+.drilling-location-row .form-label {
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-2);
 }
 
-.drilling-location-row .text-muted-detail {
-  margin: 0;
-  font-size: 0.8rem;
-}
+.drilling-location-row .text-muted { margin: 0; font-size: var(--font-xs); }
 
-.drilling-location-row button {
-  align-self: center;
-  justify-self: flex-start;
-}
+.drilling-location-row .btn { align-self: center; }
 
-.drilling-action-card {
-  padding: 0;
-}
+.drilling-action-card { padding: 0; }
+.drilling-action-card .finishing-action-bar { padding: var(--space-3); }
 
-.drilling-action-card .finishing-action-toolbar {
-  padding: 12px;
-}
-
-@media (--bp-narrow) {
-  .drilling-location-row {
-    grid-template-columns: 1fr;
-  }
+@media (max-width: 760px) {
+  .drilling-location-row { grid-template-columns: 1fr; }
 }

--- a/docs/css/tabs/finishing.css
+++ b/docs/css/tabs/finishing.css
@@ -1,158 +1,82 @@
 /* =============================================
- * Finishing & Score Layouts
+ * Finishing Planner
  * ---------------------------------------------
- * Layout helpers that organize finishing, score,
- * and perforation content inside their tabs.
+ * Shared layouts for score, perforation, and
+ * drilling planning panels.
  * ============================================= */
+.finishing-pane { display: grid; gap: var(--space-5); }
 
-/* This container stacks score planning panels and supplemental results. */
-.finishing-score-pane { --gap: var(--gap-spacious); }
-
-/* This layout splits inputs and results into columns for large screens. */
-.finishing-score-layout {
-  --gap: var(--gap-spacious);
+.finishing-layout {
+  display: grid;
+  gap: var(--space-5);
   grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
   align-items: start;
 }
 
-/* Each column stacks cards in the scoring and perforation tabs. */
-.finishing-score-column { --gap: var(--gap-spacious); }
+.finishing-column { display: grid; gap: var(--space-5); }
 
-/* This card introduces the scoring/perforation section with contextual copy. */
-.finishing-score-card-intro { --gap: var(--gap-snug); }
+.finishing-card { display: grid; gap: var(--space-3); }
+.finishing-card--intro { gap: var(--space-2); }
 
-/* This modifier adds breathing room between result cards. */
-.finishing-score-results { --gap: var(--gap-roomy); }
-
-/* This base card adds vertical rhythm for score configuration forms. */
-.finishing-score-card { --gap: var(--gap-roomy); }
-
-/* Horizontal score cards allow wider headlines to wrap cleanly. */
-.finishing-score-card-horizontal .finishing-score-card-title p,
-.finishing-score-card-vertical .finishing-score-card-title p {
-  max-width: none;
-}
-
-/* This header aligns titles and preset buttons for score cards. */
-.finishing-score-card-header {
+.finishing-card__header {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--border-overlay);
+  gap: var(--space-3);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border-muted);
 }
 
-/* This container limits explanatory copy to a comfortable width. */
-.finishing-score-card-title p {
-  margin: 0;
-  max-width: 460px;
-}
+.finishing-card__title p { margin: 0; max-width: 460px; }
 
-/* This group arranges preset buttons adjacent to score headings. */
-.finishing-score-preset-group {
+.finishing-preset-group {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
-/* Preset buttons maintain a minimum width to keep labels legible. */
-.finishing-score-preset-group .action-button {
-  min-width: 90px;
-  text-align: center;
-}
+.finishing-preset-group .btn { min-width: 90px; text-align: center; }
 
-/* This container stacks score input labels and helper copy. */
-.finishing-score-field { --gap: var(--gap-snug); }
+.finishing-field { display: grid; gap: var(--space-2); }
 
-/* Score labels switch to a column layout for multi-line instructions. */
-.finishing-score-field label {
+.finishing-field .form-label {
   flex-direction: column;
   align-items: stretch;
   justify-content: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
-/* Score labels inherit a smaller caption style for descriptors. */
-.finishing-score-field label span {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-}
+.finishing-field .form-label span { font-size: var(--font-sm); color: var(--color-text-secondary); }
 
-/* Inputs span the full width when editing score values. */
-.finishing-score-field label input {
-  width: 100%;
-  text-align: left;
-}
+.finishing-field .form-control { text-align: left; }
 
-/* Locked score inputs adopt a disabled palette to indicate read-only state. */
-.finishing-score-field label input.is-locked {
-  background: var(--surface-control);
-  border-color: var(--border-muted);
-  color: var(--text-secondary);
+.finishing-field .form-control.is-locked {
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-muted);
+  color: var(--color-text-secondary);
   cursor: not-allowed;
   opacity: 0.85;
 }
 
-/* Helper text reinforces how values are interpreted. */
-.finishing-score-hint {
-  margin: 0;
-  font-size: 0.85rem;
+.finishing-hint { margin: 0; font-size: var(--font-sm); color: var(--color-text-muted); }
+
+.finishing-action-bar { justify-content: space-between; }
+
+.finishing-action-card { padding: 0; }
+.finishing-action-card .finishing-action-bar { padding: var(--space-3); }
+
+.finishing-results { display: grid; gap: var(--space-3); }
+.finishing-results p { margin: 0; font-size: var(--font-sm); }
+
+.finishing-table-grid { display: grid; gap: var(--space-4); grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+
+@media (max-width: 960px) {
+  .finishing-layout { grid-template-columns: 1fr; }
 }
 
-/* Action toolbars for score/perforation tabs span available width for buttons and copy. */
-.finishing-action-toolbar {
-  justify-content: space-between;
-}
-
-/* This card removes default padding so the toolbar can hug the edges. */
-.finishing-action-card {
-  padding: 0;
-}
-
-/* Padding is reintroduced within the toolbar for comfortable spacing. */
-.finishing-action-card .finishing-action-toolbar {
-  padding: 12px;
-}
-
-/* Inline helper text inside action toolbars uses the muted tone. */
-.finishing-action-toolbar .text-muted-detail {
-  font-size: 0.85rem;
-}
-
-/* Result cards tighten spacing for summary tables and descriptions. */
-.finishing-score-table-card { --gap: var(--gap-default); }
-
-/* Copy inside result cards uses a smaller type scale. */
-.finishing-score-table-card p {
-  margin: 0;
-  font-size: 0.85rem;
-}
-
-/* Result grids arrange tables responsively based on available width. */
-.finishing-score-results-grid {
-  --gap: var(--gap-roomy);
-  --grid-min: 260px;
-}
-
-@media (--bp-medium) {
-  /* Score layouts collapse to a single column on mid-sized screens. */
-  .finishing-score-layout {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (--bp-compact) {
-  /* Score headers stack elements vertically on narrow devices. */
-  .finishing-score-card-header {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  /* Preset buttons left-align when stacked vertically. */
-  .finishing-score-preset-group {
-    justify-content: flex-start;
-  }
+@media (max-width: 720px) {
+  .finishing-card__header { flex-direction: column; align-items: stretch; }
+  .finishing-preset-group { justify-content: flex-start; }
 }

--- a/docs/css/tokens.css
+++ b/docs/css/tokens.css
@@ -1,120 +1,85 @@
 /* =============================================
- * Theme Tokens
+ * Design Tokens
  * ---------------------------------------------
- * Consolidated custom properties for surfaces,
- * borders, typography, accents, spacing, and
- * responsive thresholds.
+ * Single source of truth for Kev's calculator
+ * colors, typography, spacing, radii, motion,
+ * and visualizer accents.
  * ============================================= */
-@custom-media --bp-mobile (max-width: 600px);
-@custom-media --bp-tablet (max-width: 900px);
-@custom-media --bp-narrow (max-width: 720px);
-@custom-media --bp-compact (max-width: 680px);
-@custom-media --bp-medium (max-width: 960px);
-@custom-media --bp-laptop (max-width: 1024px);
-@custom-media --bp-desktop (min-width: 960px);
-
 :root {
-  /* -----------------------------
-     SURFACE
-  ----------------------------- */
-  --surface-bg: #0f1115;
-  --surface-panel: #171a21;
-  --surface-overlay: #11141b;
-  --surface-control: #1a1f2a;
-  --surface-control-hover: color-mix(in srgb, var(--surface-control) 85%, var(--text-inverse) 15%);
-  --surface-panel-elevated: var(--surface-panel);
-  --surface-panel-overlay: var(--surface-overlay);
-  --surface-card: var(--surface-panel);
-  --surface-inset: color-mix(in srgb, var(--surface-panel) 80%, var(--surface-bg) 20%);
-  --surface-paper: #fff;
+  color-scheme: dark;
 
-  /* -----------------------------
-     BORDER
-  ----------------------------- */
-  --border-default: #222632;
-  --border-strong: #2c3446;
-  --border-accent: #1f8a8a;
-  --border-subtle: color-mix(in srgb, var(--border-default) 70%, transparent);
-  --border-muted: var(--border-default);
-  --border-overlay: var(--border-default);
-  --border-dashed: color-mix(in srgb, var(--border-default) 85%, transparent);
+  /* ---- Color palette ---- */
+  --color-surface-0: #0f1115;
+  --color-surface-1: #171a21;
+  --color-surface-2: #1a1f2a;
+  --color-surface-3: #11141b;
+  --color-border: #222632;
+  --color-border-strong: #2c3446;
+  --color-border-muted: color-mix(in srgb, var(--color-border) 70%, transparent);
+  --color-border-accent: #1f8a8a;
+  --color-accent: #5eead4;
+  --color-accent-soft: color-mix(in srgb, var(--color-accent) 16%, var(--color-surface-2));
+  --color-accent-glow: color-mix(in srgb, var(--color-accent) 35%, transparent);
+  --color-text-primary: #e6e9ef;
+  --color-text-secondary: #b8c0cc;
+  --color-text-muted: #8892a6;
+  --color-text-inverse: #000000;
+  --color-text-bright: #f8fafc;
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-paper: #ffffff;
 
-  /* -----------------------------
-     TEXT
-  ----------------------------- */
-  --text-primary: #e6e9ef;
-  --text-secondary: #b8c0cc;
-  --text-tertiary: #9aa4b8;
-  --text-muted: #8892a6;
-  --text-bright: #e2e8f0;
-  --text-inverse: #000;
+  /* ---- Typography ---- */
+  --font-family-sans: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  --font-xs: 0.8rem;
+  --font-sm: 0.9rem;
+  --font-md: 1rem;
+  --font-lg: 1.25rem;
+  --font-xl: 1.5rem;
+  --line-height-base: 1.45;
 
-  /* -----------------------------
-     ACCENT
-  ----------------------------- */
-  --accent-primary: #5eead4;
-  --accent-focus-ring: color-mix(in srgb, var(--accent-primary) 45%, transparent);
-  --accent-surface-tint: color-mix(in srgb, var(--accent-primary) 16%, var(--surface-control));
-  --accent-surface-veil: color-mix(in srgb, var(--accent-primary) 35%, transparent);
-  --status-danger: #ef4444;
-  --status-success: #22c55e;
-  --status-warning: #f59e0b;
-
-  /* Measurement accents */
-  --measure-layout: #00aeef;
-  --measure-document: #00b050;
-  --measure-margin: #ffa500;
-  --measure-cut: #ff0000;
-  --measure-score: #800080;
-  --measure-hole: #2563eb;
-  --measure-cut-bg-hover: color-mix(in srgb, var(--measure-cut) 15%, transparent);
-  --measure-cut-bg-selected: color-mix(in srgb, var(--measure-cut) 25%, transparent);
-  --measure-score-bg-hover: color-mix(in srgb, var(--measure-score) 15%, transparent);
-  --measure-score-bg-selected: color-mix(in srgb, var(--measure-score) 25%, transparent);
-  --measure-hole-bg-hover: color-mix(in srgb, var(--measure-hole) 15%, transparent);
-  --measure-hole-bg-selected: color-mix(in srgb, var(--measure-hole) 25%, transparent);
-  --measure-cut-glow: #ff6666;
-  --measure-score-glow: #c4b5fd;
-  --measure-hole-glow: #93c5fd;
-  --measure-cut-glow-soft: color-mix(in srgb, var(--measure-cut-glow) 60%, transparent);
-  --measure-score-glow-soft: color-mix(in srgb, var(--measure-score-glow) 60%, transparent);
-  --measure-hole-glow-soft: color-mix(in srgb, var(--measure-hole-glow) 60%, transparent);
-  --measure-line-outline: #334155;
-  --measure-line-layout: #38bdf8;
-  --measure-line-printable: #f97316;
-  --measure-line-cut: #22d3ee;
-  --measure-line-slit: #facc15;
-  --measure-line-score: #a855f7;
-  --measure-line-perf: #fb7185;
-
-  /* Shadows */
-  --shadow-elevated: color-mix(in srgb, var(--surface-bg) 65%, transparent);
-  --shadow-deep: color-mix(in srgb, var(--text-inverse) 25%, transparent);
-
-  /* Spacing */
-  --gap-tight: 6px;
-  --gap-snug: 8px;
-  --gap-default: 12px;
-  --gap-roomy: 16px;
-  --gap-spacious: 18px;
+  /* ---- Spacing scale ---- */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
   --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
 
-  /* Typography */
-  --font-xs: 0.8rem;
-  --font-sm: 0.9rem;
-}
+  /* ---- Radii & elevation ---- */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.4);
 
-/* Legacy alias bridge */
-.legacy {
-  --bg: var(--surface-bg);
-  --panel: var(--surface-panel);
-  --muted: var(--text-muted);
-  --text: var(--text-primary);
-  --accent: var(--accent-primary);
-  --danger: var(--status-danger);
-  --ok: var(--status-success);
-  --warn: var(--status-warning);
+  /* ---- Motion ---- */
+  --motion-fast: 150ms;
+  --motion-slow: 300ms;
+
+  /* ---- Layout tokens ---- */
+  --layout-max-width: 1280px;
+  --layout-panel-width: min(1280px, 100%);
+
+  /* ---- Visualizer tokens ---- */
+  --viz-stage-bg: var(--color-surface-2);
+  --viz-layer-panel-bg: #1b2230;
+  --viz-stage-border: var(--color-border-strong);
+  --viz-layer-border: var(--color-border);
+  --viz-layer-hover: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  --viz-layer-selected: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  --viz-line-outline: #334155;
+  --viz-line-layout: #38bdf8;
+  --viz-line-printable: #f97316;
+  --viz-line-cut: #22d3ee;
+  --viz-line-score: #a855f7;
+  --viz-line-slit: #facc15;
+  --viz-line-perf: #fb7185;
+  --viz-line-hole: #2563eb;
+  --viz-fill-margin: rgba(249, 115, 22, 0.28);
+  --viz-fill-document: rgba(94, 234, 212, 0.18);
+  --viz-glow-cut: #ff6666;
+  --viz-glow-score: #c4b5fd;
+  --viz-glow-hole: #93c5fd;
 }

--- a/docs/css/visualizer.css
+++ b/docs/css/visualizer.css
@@ -1,305 +1,249 @@
 /* =============================================
- * Visualizer & Measurement System
+ * Visualizer System
  * ---------------------------------------------
- * Shared measurement theming, table ↔ preview
- * linkage, SVG styling, and legend presentation.
+ * Preview stage styling, measurement feedback,
+ * layer toggles, and print-mode helpers.
  * ============================================= */
-.measurement-theme {
-  --measurement-line-width: 1;
-  --measurement-line-opacity: 0.9;
-  --measurement-score-dash: 6 4;
-  --measurement-outline-stroke: var(--measure-line-outline);
-  --measurement-margin-fill: rgba(249, 115, 22, 0.28);
-  --measurement-layout-stroke: var(--measure-line-layout);
-  --measurement-printable-stroke: var(--measure-line-printable);
-  --measurement-document-fill: rgba(94, 234, 212, 0.18);
-  --measurement-document-stroke: #5eead4;
+.viz-theme {
+  --viz-line-width: 1;
+  --viz-line-opacity: 0.9;
+  --viz-score-dash: 6 4;
 }
 
-.measurement-row {
+.viz-measure-row {
   cursor: pointer;
-  transition: background 0.18s ease, color 0.18s ease;
+  transition: background var(--motion-fast) ease, color var(--motion-fast) ease;
 }
 
-.measurement-row:focus {
-  outline: 1px solid var(--accent-primary);
-  outline-offset: -2px;
+.viz-measure-row:focus { outline: 1px solid var(--color-accent); outline-offset: -2px; }
+
+.viz-measure-row:is(.is-hovered, .is-selected) { color: var(--color-text-bright); }
+
+.viz-measure-row[data-measure-type="cut"]:is(.is-hovered, .is-selected) {
+  background: color-mix(in srgb, var(--color-danger) 18%, transparent);
 }
 
-.measurement-row.is-hovered,
-.measurement-row.is-selected { color: var(--text-bright); }
+.viz-measure-row:is([data-measure-type*="score"], [data-measure-type="perforation"], [data-measure-type="slit"]):is(.is-hovered, .is-selected) {
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+}
 
-.measurement-row[data-measure-type="cut"].is-hovered,
-.measurement-row[data-measure-type="cut"].is-selected { background: var(--measure-cut-bg-hover); }
+.viz-measure-row[data-measure-type="hole"]:is(.is-hovered, .is-selected) {
+  background: color-mix(in srgb, var(--color-warning) 22%, transparent);
+}
 
-.measurement-row[data-measure-type="cut"].is-selected { background: var(--measure-cut-bg-selected); }
-
-.measurement-row[data-measure-type="score-horizontal"].is-hovered,
-.measurement-row[data-measure-type="score-vertical"].is-hovered,
-.measurement-row[data-measure-type="perforation"].is-hovered,
-.measurement-row[data-measure-type="slit"].is-hovered { background: var(--measure-score-bg-hover); }
-
-.measurement-row[data-measure-type="score-horizontal"].is-selected,
-.measurement-row[data-measure-type="score-vertical"].is-selected,
-.measurement-row[data-measure-type="perforation"].is-selected,
-.measurement-row[data-measure-type="slit"].is-selected { background: var(--measure-score-bg-selected); }
-
-.measurement-row[data-measure-type="hole"].is-hovered,
-.measurement-row[data-measure-type="hole"].is-selected { background: var(--measure-hole-bg-hover); }
-
-.measurement-row[data-measure-type="hole"].is-selected { background: var(--measure-hole-bg-selected); }
-
-.measurement-theme .measurement-line {
+.viz-theme .viz-line {
   pointer-events: auto;
-  transition: stroke 0.2s ease, stroke-width 0.2s ease, opacity 0.2s ease;
-  opacity: var(--measurement-line-opacity);
+  opacity: var(--viz-line-opacity);
+  transition: stroke var(--motion-fast) ease, stroke-width var(--motion-fast) ease, opacity var(--motion-fast) ease;
 }
 
-.measurement-theme .measurement-line.is-hovered,
-.measurement-theme .measurement-line.is-selected {
+.viz-theme .viz-line:is(.is-hovered, .is-selected) {
   opacity: 1;
-  stroke-width: calc(var(--measurement-line-width) * 3);
+  stroke-width: calc(var(--viz-line-width) * 3);
 }
 
-.measurement-theme .measurement-line[data-measure-type="cut"] {
-  stroke: var(--measure-line-cut);
+.viz-theme .viz-line[data-measure-type="cut"] { stroke: var(--viz-line-cut); }
+
+.viz-theme .viz-line:is([data-measure-type="score"], [data-measure-type*="score"]) {
+  stroke: var(--viz-line-score);
+  stroke-dasharray: var(--viz-score-dash);
 }
 
-.measurement-theme .measurement-line[data-measure-type="score-horizontal"],
-.measurement-theme .measurement-line[data-measure-type="score-vertical"] {
-  stroke: var(--measure-line-score);
-  stroke-dasharray: var(--measurement-score-dash);
+.viz-theme .viz-line[data-measure-type="slit"] {
+  stroke: var(--viz-line-slit);
+  stroke-dasharray: var(--viz-score-dash);
 }
 
-.measurement-theme .measurement-line[data-measure-type="slit"] {
-  stroke: var(--measure-line-slit);
-  stroke-dasharray: var(--measurement-score-dash);
-}
-
-.measurement-theme .measurement-line[data-measure-type="perforation"] {
-  stroke: var(--measure-line-perf);
-  stroke-dasharray: var(--measurement-score-dash);
+.viz-theme .viz-line[data-measure-type="perforation"] {
+  stroke: var(--viz-line-perf);
+  stroke-dasharray: var(--viz-score-dash);
   opacity: 0.95;
 }
 
-.measurement-theme .measurement-line[data-measure-type="hole"] {
-  stroke: var(--measure-hole);
+.viz-theme .viz-line[data-measure-type="hole"] { stroke: var(--viz-line-hole); }
+
+.viz-theme .viz-line[data-measure-type="cut"]:is(.is-hovered, .is-selected) {
+  stroke: var(--viz-glow-cut);
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--viz-glow-cut) 60%, transparent));
 }
 
-.measurement-theme .measurement-line[data-measure-type="cut"].is-hovered,
-.measurement-theme .measurement-line[data-measure-type="cut"].is-selected {
-  stroke: var(--measure-cut-glow);
-  filter: drop-shadow(0 0 4px var(--measure-cut-glow-soft));
+.viz-theme .viz-line:is([data-measure-type*="score"], [data-measure-type="slit"], [data-measure-type="perforation"]):is(.is-hovered, .is-selected) {
+  stroke: var(--viz-glow-score);
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--viz-glow-score) 60%, transparent));
 }
 
-.measurement-theme .measurement-line[data-measure-type="score-horizontal"].is-hovered,
-.measurement-theme .measurement-line[data-measure-type="score-horizontal"].is-selected,
-.measurement-theme .measurement-line[data-measure-type="score-vertical"].is-hovered,
-.measurement-theme .measurement-line[data-measure-type="score-vertical"].is-selected,
-.measurement-theme .measurement-line[data-measure-type="slit"].is-hovered,
-.measurement-theme .measurement-line[data-measure-type="slit"].is-selected,
-.measurement-theme .measurement-line[data-measure-type="perforation"].is-hovered,
-.measurement-theme .measurement-line[data-measure-type="perforation"].is-selected {
-  stroke: var(--measure-score-glow);
-  filter: drop-shadow(0 0 4px var(--measure-score-glow-soft));
+.viz-theme .viz-line[data-measure-type="hole"]:is(.is-hovered, .is-selected) {
+  stroke: var(--viz-glow-hole);
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--viz-glow-hole) 60%, transparent));
 }
 
-.measurement-theme .measurement-line[data-measure-type="hole"].is-hovered,
-.measurement-theme .measurement-line[data-measure-type="hole"].is-selected {
-  stroke: var(--measure-hole-glow);
-  filter: drop-shadow(0 0 4px var(--measure-hole-glow-soft));
+.viz-theme .viz-line[data-measure-type="hole"] + circle {
+  fill: color-mix(in srgb, var(--viz-line-hole) 12%, transparent);
+  stroke: var(--viz-line-hole);
+  stroke-width: var(--viz-line-width);
 }
 
-.measurement-theme .measurement-line[data-measure-type="hole"] + circle {
-  fill: color-mix(in srgb, var(--measure-hole) 12%, transparent);
-  stroke: var(--measure-hole);
-  stroke-width: var(--measurement-line-width);
-}
+.viz-theme svg .svg-line { stroke-linecap: round; }
+.viz-theme svg .svg-sheet-outline { fill: none; stroke: var(--viz-line-outline); stroke-width: 1.5; }
+.viz-theme svg .svg-nonprintable-region { fill: var(--viz-fill-margin); stroke: none; }
+.viz-theme svg .svg-printable-outline { fill: none; stroke: var(--viz-line-printable); stroke-width: 1; }
+.viz-theme svg .svg-layout-area { fill: none; stroke: var(--viz-line-layout); stroke-width: 1.5; }
+.viz-theme svg .svg-document-area { fill: var(--viz-fill-document); stroke: var(--viz-line-layout); stroke-width: 1; }
+.viz-theme svg .svg-cut-line { stroke: var(--viz-line-cut); stroke-width: var(--viz-line-width); }
+.viz-theme svg .svg-slit-line { stroke: var(--viz-line-slit); stroke-width: var(--viz-line-width); stroke-dasharray: var(--viz-score-dash); }
+.viz-theme svg .svg-score-line { stroke: var(--viz-line-score); stroke-width: var(--viz-line-width); stroke-dasharray: var(--viz-score-dash); }
+.viz-theme svg .svg-perforation-line { stroke: var(--viz-line-perf); stroke-width: var(--viz-line-width); stroke-dasharray: var(--viz-score-dash); }
+.viz-theme svg .svg-hole { fill: color-mix(in srgb, var(--viz-line-hole) 12%, transparent); stroke: var(--viz-line-hole); stroke-width: var(--viz-line-width); }
 
-.measurement-theme svg { display: block; }
+/* ---- Layout ---- */
+.viz-shell { display: grid; gap: var(--space-4); }
 
-.measurement-theme svg .svg-line { stroke-linecap: round; }
-.measurement-theme svg .svg-sheet-outline {
-  fill: none;
-  stroke: var(--measurement-outline-stroke);
-  stroke-width: 1.5;
-}
-
-.measurement-theme svg .svg-nonprintable-region { fill: var(--measurement-margin-fill); stroke: none; }
-.measurement-theme svg .svg-printable-outline { fill: none; stroke: var(--measurement-printable-stroke); stroke-width: 1; }
-.measurement-theme svg .svg-layout-area { fill: none; stroke: var(--measurement-layout-stroke); stroke-width: 1.5; }
-.measurement-theme svg .svg-document-area { fill: var(--measurement-document-fill); stroke: var(--measurement-document-stroke); stroke-width: 1; }
-.measurement-theme svg .svg-cut-line { stroke: var(--measure-line-cut); stroke-width: var(--measurement-line-width); }
-.measurement-theme svg .svg-slit-line { stroke: var(--measure-line-slit); stroke-width: var(--measurement-line-width); }
-.measurement-theme svg .svg-score-line { stroke: var(--measure-line-score); stroke-width: var(--measurement-line-width); }
-.measurement-theme svg .svg-perforation-line {
-  stroke: var(--measure-line-perf);
-  stroke-width: var(--measurement-line-width);
-  stroke-dasharray: var(--measurement-score-dash);
-}
-
-.measurement-theme svg .svg-hole {
-  fill: color-mix(in srgb, var(--measure-hole) 12%, transparent);
-  stroke: var(--measure-hole);
-  stroke-width: var(--measurement-line-width);
-}
-
-.sheet-preview-layout {
+.viz-layout {
   display: flex;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: stretch;
+  flex-wrap: wrap;
 }
 
-.sheet-preview-stage,
-.print-preview-stage {
-  background: var(--surface-panel-elevated);
-  border: 1px solid var(--border-strong);
-  border-radius: 12px;
+.viz-stage {
+  flex: 1 1 420px;
+  min-height: 360px;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 360px;
-  flex: 1;
+  padding: var(--space-3);
+  --layout-card-bg: var(--viz-stage-bg);
+  --layout-card-border: var(--viz-stage-border);
+  --layout-card-shadow: var(--shadow-lg);
+  --layout-card-padding: var(--space-3);
 }
 
-.sheet-preview-container { --gap: 8px; }
-
-.layer-visibility-panel {
-  background: var(--surface-panel-overlay);
-  border: 1px solid var(--border-overlay);
-  border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-width: 220px;
-  max-width: 260px;
-  box-shadow: 0 12px 24px var(--shadow-elevated);
+.viz-layers {
+  flex: 0 0 240px;
+  max-width: 280px;
+  --layout-card-bg: var(--viz-layer-panel-bg);
+  --layout-card-border: var(--viz-layer-border);
+  --layout-card-shadow: var(--shadow-lg);
 }
 
-.layer-visibility-panel .visualizer-visibility-toggles {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: stretch;
-}
+.viz-toggle-list { display: grid; gap: var(--space-2); }
 
-.visualizer-visibility-toggles {
-  display: flex;
-  gap: 8px;
+.viz-layer-toggle {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-2);
   align-items: center;
-  flex-wrap: wrap;
-  margin: 0;
-}
-
-.sheet-preview-legend {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  font-size: 0.9rem;
-  margin-top: 8px;
-  color: var(--text-secondary);
-}
-
-.legend-swatch-layout-area { background: var(--measure-layout); }
-.legend-swatch-documents { background: var(--measure-document); }
-.legend-swatch-non-printable { background: var(--measure-margin); }
-.legend-swatch-cuts { background: var(--measure-cut); }
-.legend-swatch-slits,
-.legend-swatch-perforations,
-.legend-swatch-scores { background: var(--measure-score); }
-.legend-swatch-holes { background: var(--measure-hole); }
-
-.print-preview-stage {
-  position: relative;
-  border: 1px solid var(--border-default);
-  border-radius: 12px;
-  background: var(--surface-overlay);
-  min-height: 280px;
-  padding: 16px;
-  overflow: auto;
-}
-
-.print-preview-sheet {
-  background: var(--surface-paper);
-  color: var(--text-inverse);
-  box-shadow: 0 0 0 1px var(--border-default), 0 24px 48px -32px var(--shadow-deep);
-  padding: 12px;
-}
-
-.print-preview-empty {
-  max-width: 360px;
-  text-align: center;
-  color: var(--text-secondary);
-  display: grid;
-  gap: 6px;
-}
-
-.print-preview-stage svg { display: block; }
-
-.print-summary-grid {
-  margin: 0;
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.print-summary-grid dt {
-  margin: 0;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--text-secondary);
-}
-
-.print-summary-grid dd {
-  margin: 2px 0 0;
-  font-variant-numeric: tabular-nums;
-  color: var(--text-primary);
-}
-
-.print-layer-selector {
-  border: 1px solid var(--border-default);
-  border-radius: 10px;
-  padding: 12px;
-  display: grid;
-  gap: 12px;
-}
-
-.print-layer-selector legend { padding: 0 6px; font-size: 0.9rem; color: var(--text-secondary); }
-
-.print-layer-options {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.print-layer-option {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
-  background: var(--surface-overlay);
-  color: var(--text-secondary);
   cursor: pointer;
-  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
 }
 
-.print-layer-option:hover {
-  border-color: var(--border-accent);
-  color: var(--text-primary);
+.viz-layer-input {
+  appearance: none;
+  inline-size: 18px;
+  block-size: 18px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--viz-layer-border);
+  background: var(--color-surface-2);
+  display: grid;
+  place-items: center;
+  transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }
 
-.print-layer-option input[type="checkbox"] {
-  margin: 0;
-  accent-color: var(--accent-primary);
+.viz-layer-input::after {
+  content: '';
+  width: 8px;
+  height: 12px;
+  border: 2px solid var(--color-surface-1);
+  border-top: 0;
+  border-left: 0;
+  transform: rotate(45deg) scale(0);
+  transform-origin: center;
+  transition: transform var(--motion-fast) ease;
 }
 
-.print-layout-grid { gap: 18px; }
-.print-controls-card { gap: 18px; }
-.print-preview-card { gap: 16px; }
+.viz-layer-input:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 
-.print-preview-stage .svg-sheet-outline { stroke-width: 1.5; }
+.viz-layer-input:checked {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent-glow);
+}
+
+.viz-layer-input:checked::after { transform: rotate(45deg) scale(1); }
+
+.viz-layer-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--viz-layer-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-2);
+  color: var(--color-text-secondary);
+  transition: border-color var(--motion-fast) ease, background var(--motion-fast) ease, color var(--motion-fast) ease;
+}
+
+.viz-layer-toggle:hover .viz-layer-label {
+  border-color: var(--color-border-accent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  color: var(--color-text-primary);
+}
+
+.viz-layer-input:checked + .viz-layer-label {
+  border-color: color-mix(in srgb, var(--color-accent) 60%, var(--viz-layer-border));
+  background: var(--viz-layer-selected);
+  color: var(--color-text-primary);
+  box-shadow: 0 0 0 1px var(--color-accent-glow);
+}
+
+.viz-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+}
+
+.viz-legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.viz-legend-swatch[data-layer="layout"] { background: var(--viz-line-layout); }
+.viz-legend-swatch[data-layer="docs"] { background: var(--color-accent); }
+.viz-legend-swatch[data-layer="non-printable"] { background: var(--color-warning); }
+.viz-legend-swatch[data-layer="cuts"] { background: var(--color-danger); }
+.viz-legend-swatch[data-layer="scores"] { background: var(--viz-line-score); }
+.viz-legend-swatch[data-layer="slits"],
+.viz-legend-swatch[data-layer="perforations"] { background: var(--viz-line-perf); }
+.viz-legend-swatch[data-layer="holes"] { background: var(--viz-line-hole); }
+
+/* ---- Print preview ---- */
+.print-stage {
+  position: relative;
+  min-height: 280px;
+  padding: var(--space-4);
+  overflow: auto;
+  --layout-card-bg: var(--color-surface-3);
+  --layout-card-border: var(--color-border);
+  --layout-card-shadow: 0 24px 48px -32px rgba(0, 0, 0, 0.55);
+  --layout-card-padding: var(--space-4);
+}
+
+.print-sheet {
+  background: var(--color-paper);
+  color: var(--color-text-inverse);
+  box-shadow: 0 0 0 1px var(--color-border), 0 24px 48px -32px rgba(0, 0, 0, 0.55);
+  padding: var(--space-3);
+}
+
+.print-summary { display: grid; gap: var(--space-3); grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.print-summary dt { margin: 0; font-size: var(--font-sm); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-text-secondary); }
+.print-summary dd { margin: 2px 0 0; font-variant-numeric: tabular-nums; color: var(--color-text-primary); }
+
+/* ---- Responsive ---- */
+@media (max-width: 900px) {
+  .viz-layout { flex-direction: column; }
+  .viz-layers { width: 100%; max-width: none; }
+}

--- a/docs/html-partials/fragments/app-header.html
+++ b/docs/html-partials/fragments/app-header.html
@@ -3,13 +3,13 @@
     - Injected by docs/js/utils/fragment-loader.js during docs/js/bootstrap.js when a
       [data-partial="app-header"] placeholder is detected (before app.js initializes).
   Key selectors:
-    - <header class="layout-app-header"> root element styled by layout-app-shell rules.
-    - .text-muted-detail for the supporting tagline copy.
+    - <header class="layout-header layout-stack"> root element styled by layout shell rules.
+    - .text-muted for the supporting tagline copy.
   JS dependencies:
     - No direct scripts target this fragment; it simply occupies the shell header space
       once the fragment loader swaps it in.
 -->
-<header class="layout-app-header stack">
+<header class="layout-header layout-stack" data-gap="snug">
   <h1>Kevin’s Bitchin’ Print Calculator</h1>
-  <p class="text-muted-detail">Dial in your sheet specs, finishing steps, and print-ready outputs from one bitchin’ workspace.</p>
+  <p class="text-muted">Dial in your sheet specs, finishing steps, and print-ready outputs from one bitchin’ workspace.</p>
 </header>

--- a/docs/html-partials/fragments/tab-nav.html
+++ b/docs/html-partials/fragments/tab-nav.html
@@ -3,21 +3,21 @@
     - Injected by docs/js/utils/fragment-loader.js during docs/js/bootstrap.js when a
       [data-partial="tab-nav"] placeholder is encountered (prior to tab registry setup).
   Key selectors:
-    - .nav-bar with .output-tab-trigger buttons for each tab.
+    - .tabs-nav with .tabs-trigger buttons for each tab.
     - data-tab attributes (inputs, summary, finishing, program-sequence, scores, perforations, warnings, print, presets).
   JS dependencies:
-    - docs/js/tabs/registry.js binds click listeners to .output-tab-trigger nodes and
+    - docs/js/tabs/registry.js binds click listeners to .tabs-trigger nodes and
       uses their data-tab values to drive panel activation.
 -->
-<nav class="nav-bar nav-bar--tabs output-tab-navigation print-hidden">
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger is-active" data-tab="inputs">Inputs</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="summary">Summary</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="finishing">Cuts / Slits</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="program-sequence">Program Sequence</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="scores">Scores</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="perforations">Perforations</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="drilling">Drilling</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="warnings">Warnings</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="print">Print</button>
-  <button type="button" class="nav-trigger nav-trigger--tab output-tab-trigger" data-tab="presets">Presets</button>
+<nav class="tabs-nav layout-cluster print-hidden" data-gap="snug">
+  <button type="button" class="tabs-trigger is-active" data-tab="inputs">Inputs</button>
+  <button type="button" class="tabs-trigger" data-tab="summary">Summary</button>
+  <button type="button" class="tabs-trigger" data-tab="finishing">Cuts / Slits</button>
+  <button type="button" class="tabs-trigger" data-tab="program-sequence">Program Sequence</button>
+  <button type="button" class="tabs-trigger" data-tab="scores">Scores</button>
+  <button type="button" class="tabs-trigger" data-tab="perforations">Perforations</button>
+  <button type="button" class="tabs-trigger" data-tab="drilling">Drilling</button>
+  <button type="button" class="tabs-trigger" data-tab="warnings">Warnings</button>
+  <button type="button" class="tabs-trigger" data-tab="print">Print</button>
+  <button type="button" class="tabs-trigger" data-tab="presets">Presets</button>
 </nav>

--- a/docs/html-partials/fragments/visualizer.html
+++ b/docs/html-partials/fragments/visualizer.html
@@ -3,78 +3,75 @@
     - Injected by docs/js/utils/fragment-loader.js during docs/js/bootstrap.js when a
       [data-partial="visualizer"] placeholder is resolved ahead of app.js boot.
   Key selectors:
-    - .sheet-preview-visualizer section housing the live preview UI.
-    - .layer-visibility-toggle-input checkboxes for layer toggles.
-    - .sheet-preview-stage > #svg used as the drawing surface.
-    - .sheet-preview-legend entries styled for layer color references.
+    - .viz-stage housing the live preview SVG canvas (#svg).
+    - .viz-layer-input checkboxes for layer toggles.
+    - .viz-legend-swatch elements communicate palette usage.
   JS dependencies:
     - docs/js/tabs/summary.js hydrates visibility toggles via get/setLayerVisibility helpers.
     - docs/js/app.js and docs/js/utils/dom.js query #svg to render and update the sheet preview.
 -->
-<section class="content-section sheet-preview-visualizer stack">
-  <div class="sheet-preview-container stack">
-    <div class="sheet-preview-layout">
-      <div class="sheet-preview-stage measurement-theme"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
-      <aside class="layer-visibility-panel print-hidden" aria-label="Layer visibility">
-        <div class="visualizer-visibility-toggles">
-          <label class="layer-visibility-option" data-layer="layout">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="layout" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-layout-area" aria-hidden="true"></i>
-              <span>Layout Area</span>
-            </span>
-          </label>
-          <label class="layer-visibility-option" data-layer="docs">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="docs" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-documents" aria-hidden="true"></i>
-              <span>Documents</span>
-            </span>
-          </label>
-          <label class="layer-visibility-option" data-layer="nonPrintable">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="nonPrintable" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-non-printable" aria-hidden="true"></i>
-              <span>Non-Printable Area</span>
-            </span>
-          </label>
-          <label class="layer-visibility-option" data-layer="cuts">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="cuts" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-cuts" aria-hidden="true"></i>
-              <span>Cuts</span>
-            </span>
-          </label>
-          <label class="layer-visibility-option" data-layer="slits">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="slits" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-slits" aria-hidden="true"></i>
-              <span>Slits</span>
-            </span>
-          </label>
-          <label class="layer-visibility-option" data-layer="scores">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="scores" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-scores" aria-hidden="true"></i>
-              <span>Scores</span>
-            </span>
-          </label>
-          <label class="layer-visibility-option" data-layer="perforations">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="perforations" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-perforations" aria-hidden="true"></i>
-              <span>Perforations</span>
-            </span>
-          </label>
-          <label class="layer-visibility-option" data-layer="holes">
-            <input class="layer-visibility-toggle-input" type="checkbox" data-layer="holes" checked />
-            <span class="layer-visibility-label">
-              <i class="legend-color-swatch legend-swatch-holes" aria-hidden="true"></i>
-              <span>Holes</span>
-            </span>
-          </label>
-        </div>
-      </aside>
-    </div>
+<section class="layout-panel viz-shell layout-stack" data-gap="cozy">
+  <div class="viz-layout">
+    <div class="layout-card viz-stage viz-theme"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
+    <aside class="layout-card layout-stack viz-layers print-hidden" data-gap="cozy" aria-label="Layer visibility">
+      <div class="viz-toggle-list">
+        <label class="viz-layer-toggle" data-layer="layout">
+          <input class="viz-layer-input" type="checkbox" data-layer="layout" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="layout" aria-hidden="true"></i>
+            <span>Layout Area</span>
+          </span>
+        </label>
+        <label class="viz-layer-toggle" data-layer="docs">
+          <input class="viz-layer-input" type="checkbox" data-layer="docs" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="docs" aria-hidden="true"></i>
+            <span>Documents</span>
+          </span>
+        </label>
+        <label class="viz-layer-toggle" data-layer="nonPrintable">
+          <input class="viz-layer-input" type="checkbox" data-layer="nonPrintable" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="non-printable" aria-hidden="true"></i>
+            <span>Non-Printable Area</span>
+          </span>
+        </label>
+        <label class="viz-layer-toggle" data-layer="cuts">
+          <input class="viz-layer-input" type="checkbox" data-layer="cuts" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="cuts" aria-hidden="true"></i>
+            <span>Cuts</span>
+          </span>
+        </label>
+        <label class="viz-layer-toggle" data-layer="slits">
+          <input class="viz-layer-input" type="checkbox" data-layer="slits" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="slits" aria-hidden="true"></i>
+            <span>Slits</span>
+          </span>
+        </label>
+        <label class="viz-layer-toggle" data-layer="scores">
+          <input class="viz-layer-input" type="checkbox" data-layer="scores" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="scores" aria-hidden="true"></i>
+            <span>Scores</span>
+          </span>
+        </label>
+        <label class="viz-layer-toggle" data-layer="perforations">
+          <input class="viz-layer-input" type="checkbox" data-layer="perforations" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="perforations" aria-hidden="true"></i>
+            <span>Perforations</span>
+          </span>
+        </label>
+        <label class="viz-layer-toggle" data-layer="holes">
+          <input class="viz-layer-input" type="checkbox" data-layer="holes" checked />
+          <span class="viz-layer-label">
+            <i class="viz-legend-swatch" data-layer="holes" aria-hidden="true"></i>
+            <span>Holes</span>
+          </span>
+        </label>
+      </div>
+    </aside>
   </div>
 </section>

--- a/docs/html-partials/templates/tab-drilling-template.html
+++ b/docs/html-partials/templates/tab-drilling-template.html
@@ -11,34 +11,34 @@
 -->
 
 <template id="tab-drilling-template">
-  <div class="finishing-score-pane stack">
-    <div class="finishing-score-layout grid">
-      <div class="finishing-score-column stack">
-        <div class="data-card stack finishing-score-card-intro">
-          <div class="finishing-score-card-title">
+  <div class="finishing-pane layout-stack" data-gap="spacious">
+    <div class="finishing-layout">
+      <div class="finishing-column">
+        <div class="layout-card finishing-card finishing-card--intro">
+          <div class="finishing-card__title layout-stack" data-gap="snug">
             <h3>Hole Drilling Planner</h3>
-            <p class="text-muted-detail">Define punching patterns that repeat for each document in the layout.</p>
+            <p class="text-muted">Define punching patterns that repeat for each document in the layout.</p>
           </div>
         </div>
-        <div class="data-card stack drilling-configuration-card">
-          <div class="finishing-score-card-header">
-            <div class="finishing-score-card-title">
+        <div class="layout-card finishing-card drilling-card">
+          <div class="finishing-card__header">
+            <div class="finishing-card__title layout-stack" data-gap="snug">
               <h3>Plan Settings</h3>
-              <p class="text-muted-detail">Choose a preset or build a custom plan relative to the document edges.</p>
+              <p class="text-muted">Choose a preset or build a custom plan relative to the document edges.</p>
             </div>
           </div>
-          <div class="drilling-plan-fields grid">
-            <label class="finishing-score-label" for="drillPreset">
+          <div class="drilling-plan-grid">
+            <label class="form-label" for="drillPreset">
               <span>Hole preset</span>
-              <select id="drillPreset">
+              <select id="drillPreset" class="form-select">
                 <option value="none">No holes</option>
                 <option value="three-hole">3-hole (left edge)</option>
                 <option value="custom">Custom</option>
               </select>
             </label>
-            <label class="finishing-score-label" for="drillSize">
+            <label class="form-label" for="drillSize">
               <span>Hole size</span>
-              <select id="drillSize">
+              <select id="drillSize" class="form-select">
                 <option value="0.25">1/4 in (0.250)</option>
                 <option value="0.1875">3/16 in (0.1875)</option>
                 <option value="0.3125">5/16 in (0.3125)</option>
@@ -46,30 +46,29 @@
               </select>
             </label>
           </div>
-          <div class="drilling-custom-config stack stack--comfortable" data-custom-config hidden>
-            <p class="text-muted-detail">
-              Add hole locations and offsets relative to the document. Alignment determines where the row begins; offsets
-              move the hole along and into the sheet.
+          <div class="drilling-custom-config layout-stack" data-gap="cozy" data-custom-config hidden>
+            <p class="text-muted drilling-note">
+              Add hole locations and offsets relative to the document. Alignment determines where the row begins; offsets move the hole along and into the sheet.
             </p>
-            <div class="drilling-location-list stack stack--comfortable" id="drillLocations"></div>
-            <button class="action-button action-button-secondary" id="drillAddLocation" type="button">Add hole location</button>
+            <div class="drilling-location-list" id="drillLocations"></div>
+            <button class="btn" id="drillAddLocation" type="button">Add hole location</button>
           </div>
           <input id="holePlanData" type="hidden" value="" />
         </div>
-        <div class="data-card drilling-action-card">
-          <div class="control-toolbar finishing-action-toolbar print-hidden">
-            <button class="action-button action-button-primary" id="applyDrilling" type="button">Apply Drilling</button>
-            <span class="text-muted-detail">Leave the preset on “No holes” to omit drilling from the layout.</span>
+        <div class="layout-card finishing-action-card">
+          <div class="form-toolbar layout-cluster finishing-action-bar print-hidden" data-gap="snug" data-align="between">
+            <button class="btn btn-primary" id="applyDrilling" type="button">Apply Drilling</button>
+            <span class="text-muted">Leave the preset on “No holes” to omit drilling from the layout.</span>
           </div>
         </div>
       </div>
-      <div class="finishing-score-column stack finishing-score-results">
-        <div class="data-card stack finishing-score-table-card">
-          <div>
+      <div class="finishing-column finishing-results">
+        <div class="layout-card finishing-results">
+          <div class="layout-stack" data-gap="snug">
             <h3>Hole Locations</h3>
-            <p class="text-muted-detail">Centers are reported from the sheet origin with diameter conversions.</p>
+            <p class="text-muted">Centers are reported from the sheet origin with diameter conversions.</p>
           </div>
-          <table class="data-table" id="tblHoles">
+          <table class="summary-table" id="tblHoles">
             <thead>
               <tr>
                 <th>Label</th>

--- a/docs/html-partials/templates/tab-finishing-template.html
+++ b/docs/html-partials/templates/tab-finishing-template.html
@@ -2,20 +2,24 @@
   Load timing:
     - Cloned into #tab-finishing via docs/js/tabs/registry.hydrateTabPanel('finishing') once templates are available from bootstrap.
   Key selectors:
-    - Tables #tblCuts and #tblSlits within .data-table cards for vertical and horizontal cut listings.
+    - Tables #tblCuts and #tblSlits within .summary-table cards for vertical and horizontal cut listings.
   JS dependencies:
     - docs/js/app.js populates these tables using docs/js/utils/dom.fillTable during calculation refreshes.
     - docs/js/utils/dom.js registers measurement IDs from the tables for hover and selection syncing across the UI.
 -->
 
 <template id="tab-finishing-template">
-  <h3 style="margin-bottom:6px">Cut &amp; Slit Systems</h3>
-  <div class="grid grid--columns-2">
-    <div class="data-card"><h3>Cuts (Y edges)</h3>
-      <table class="data-table" id="tblCuts"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
-    </div>
-    <div class="data-card"><h3>Slits (X edges)</h3>
-      <table class="data-table" id="tblSlits"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+  <div class="layout-stack" data-gap="cozy">
+    <h3>Cut &amp; Slit Systems</h3>
+    <div class="layout-grid" data-cols="2" data-gap="relaxed">
+      <div class="layout-card finishing-results">
+        <h3>Cuts (Y edges)</h3>
+        <table class="summary-table" id="tblCuts"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+      </div>
+      <div class="layout-card finishing-results">
+        <h3>Slits (X edges)</h3>
+        <table class="summary-table" id="tblSlits"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+      </div>
     </div>
   </div>
 </template>

--- a/docs/html-partials/templates/tab-inputs-template.html
+++ b/docs/html-partials/templates/tab-inputs-template.html
@@ -6,47 +6,47 @@
     - #units for unit switching and preset selects (#sheetPresetSelect, #documentPresetSelect, #gutterPresetSelect).
     - Numeric inputs for sheet, document, gutter, margin, and non-printable values (#sheetW, #sheetH, #docW, #docH, #gutH, #gutV,
       #forceAcross, #forceDown, #mTop, #mRight, #mBottom, #mLeft, #npTop, #npRight, #npBottom, #npLeft).
-    - Action controls #calcBtn, #resetBtn, and status readout #status within .input-action-toolbar.
+    - Action controls #calcBtn, #resetBtn, and status readout #status within .form-toolbar.
   JS dependencies:
     - docs/js/tabs/inputs.js binds event handlers, populates presets, toggles auto-margin mode, and reads each numeric field.
     - docs/js/app.js consumes the latest input values via the inputs tab update callback when recalculating layouts.
 -->
 
 <template id="tab-inputs-template">
-  <div class="input-layout-panel stack">
-    <div class="input-panel-header">
+  <div class="layout-stack" data-gap="relaxed">
+    <div class="layout-stack" data-gap="snug">
       <h2>Input Controls</h2>
-      <p class="text-muted-detail">Define the sheet, document, and safety settings to drive the preview.</p>
+      <p class="text-muted">Define the sheet, document, and safety settings to drive the preview.</p>
     </div>
 
-    <div class="input-scroll-container stack">
-      <div class="control-toolbar input-unit-controls print-hidden">
+    <div class="layout-stack layout-scroll" data-gap="relaxed">
+      <div class="form-toolbar layout-cluster layout-sticky print-hidden" data-gap="snug" data-align="start">
         <span>Units:</span>
-        <select id="units">
+        <select id="units" class="form-select">
           <option value="in">inches</option>
           <option value="mm">millimeters</option>
         </select>
       </div>
 
-      <div class="input-2col-grid">
-        <div class="col-left">
-          <section class="group">
+      <div class="form-grid--dual">
+        <div class="layout-stack" data-gap="relaxed">
+          <section class="form-section">
             <h2>Sheet</h2>
-            <div class="control-toolbar preset-selector-toolbar print-hidden">
-              <label>
-                <span class="text-muted-detail">Preset</span>
-                <select id="sheetPresetSelect" class="preset-selector-control">
+            <div class="form-toolbar layout-cluster print-hidden" data-gap="snug">
+              <label class="form-label">
+                <span class="text-muted">Preset</span>
+                <select id="sheetPresetSelect" class="form-select">
                   <option value="">Choose a sheet preset…</option>
                 </select>
               </label>
             </div>
-            <div class="input-field-row with-action">
-              <label><span>Width</span><input id="sheetW" type="number" step="0.25" data-inch-step="0.25"></label>
-              <label><span>Height</span><input id="sheetH" type="number" step="0.25" data-inch-step="0.25"></label>
-              <div class="input-field-action">
+            <div class="form-row" data-variant="with-action">
+              <label class="form-label"><span>Width</span><input id="sheetW" class="form-control" type="number" step="0.25" data-inch-step="0.25" /></label>
+              <label class="form-label"><span>Height</span><input id="sheetH" class="form-control" type="number" step="0.25" data-inch-step="0.25" /></label>
+              <div class="form-row-actions">
                 <button
                   type="button"
-                  class="input-swap-button"
+                  class="btn btn-swap"
                   data-swap-targets="#sheetW,#sheetH"
                   data-swap-message="Swapped sheet width and height"
                   aria-label="Swap sheet width and height"
@@ -57,23 +57,23 @@
             </div>
           </section>
 
-          <section class="group">
+          <section class="form-section">
             <h2>Document</h2>
-            <div class="control-toolbar preset-selector-toolbar print-hidden">
-              <label>
-                <span class="text-muted-detail">Preset</span>
-                <select id="documentPresetSelect" class="preset-selector-control">
+            <div class="form-toolbar layout-cluster print-hidden" data-gap="snug">
+              <label class="form-label">
+                <span class="text-muted">Preset</span>
+                <select id="documentPresetSelect" class="form-select">
                   <option value="">Choose a document preset…</option>
                 </select>
               </label>
             </div>
-            <div class="input-field-row with-action">
-              <label><span>Width</span><input id="docW" type="number" step="0.125" data-inch-step="0.125"></label>
-              <label><span>Height</span><input id="docH" type="number" step="0.125" data-inch-step="0.125"></label>
-              <div class="input-field-action">
+            <div class="form-row" data-variant="with-action">
+              <label class="form-label"><span>Width</span><input id="docW" class="form-control" type="number" step="0.125" data-inch-step="0.125" /></label>
+              <label class="form-label"><span>Height</span><input id="docH" class="form-control" type="number" step="0.125" data-inch-step="0.125" /></label>
+              <div class="form-row-actions">
                 <button
                   type="button"
-                  class="input-swap-button"
+                  class="btn btn-swap"
                   data-swap-targets="#docW,#docH"
                   data-swap-message="Swapped document width and height"
                   aria-label="Swap document width and height"
@@ -84,23 +84,23 @@
             </div>
           </section>
 
-          <section class="group">
+          <section class="form-section">
             <h2>Gutter</h2>
-            <div class="control-toolbar preset-selector-toolbar print-hidden">
-              <label>
-                <span class="text-muted-detail">Preset</span>
-                <select id="gutterPresetSelect" class="preset-selector-control">
+            <div class="form-toolbar layout-cluster print-hidden" data-gap="snug">
+              <label class="form-label">
+                <span class="text-muted">Preset</span>
+                <select id="gutterPresetSelect" class="form-select">
                   <option value="">Choose a gutter preset…</option>
                 </select>
               </label>
             </div>
-            <div class="input-field-row with-action">
-              <label><span>Horizontal</span><input id="gutH" type="number" step="0.0625" data-inch-step="0.0625"></label>
-              <label><span>Vertical</span><input id="gutV" type="number" step="0.0625" data-inch-step="0.0625"></label>
-              <div class="input-field-action">
+            <div class="form-row" data-variant="with-action">
+              <label class="form-label"><span>Horizontal</span><input id="gutH" class="form-control" type="number" step="0.0625" data-inch-step="0.0625" /></label>
+              <label class="form-label"><span>Vertical</span><input id="gutV" class="form-control" type="number" step="0.0625" data-inch-step="0.0625" /></label>
+              <div class="form-row-actions">
                 <button
                   type="button"
-                  class="input-swap-button"
+                  class="btn btn-swap"
                   data-swap-targets="#gutH,#gutV"
                   data-swap-message="Swapped gutter horizontal and vertical"
                   aria-label="Swap gutter horizontal and vertical"
@@ -111,41 +111,44 @@
             </div>
           </section>
 
-          <section class="group">
+          <section class="form-section">
             <h2>Docs (limit)</h2>
-            <div class="input-field-row">
-              <label title="Leave blank for auto max"><span>Across</span><input id="forceAcross" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
-              <label title="Leave blank for auto max"><span>Down</span><input id="forceDown" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto"></label>
+            <div class="form-row">
+              <label class="form-label" title="Leave blank for auto max"><span>Across</span><input id="forceAcross" class="form-control" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto" /></label>
+              <label class="form-label" title="Leave blank for auto max"><span>Down</span><input id="forceDown" class="form-control" type="number" step="1" min="1" data-inch-step="1" data-inch-min="1" placeholder="auto" /></label>
             </div>
           </section>
         </div>
 
-        <div class="col-right">
-          <section class="group">
+        <div class="layout-stack" data-gap="relaxed">
+          <section class="form-section">
             <h2>Margins (inside printable)</h2>
-            <div class="input-field-row-quad">
-              <label><span>Top</span><input id="mTop" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-              <label><span>Right</span><input id="mRight" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-              <label><span>Bottom</span><input id="mBottom" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
-              <label><span>Left</span><input id="mLeft" type="number" step="0.125" data-inch-step="0.125" placeholder="auto"></label>
+            <div class="form-row" data-cols="4">
+              <label class="form-label"><span>Top</span><input id="mTop" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
+              <label class="form-label"><span>Right</span><input id="mRight" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
+              <label class="form-label"><span>Bottom</span><input id="mBottom" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
+              <label class="form-label"><span>Left</span><input id="mLeft" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
             </div>
           </section>
 
-          <section class="group">
+          <section class="form-section">
             <h2>Non‑Printable Area</h2>
-            <div class="input-field-row-quad">
-              <label><span>Top</span><input id="npTop" type="number" step="0.625" data-inch-step="0.625"></label>
-              <label><span>Right</span><input id="npRight" type="number" step="0.625" data-inch-step="0.625"></label>
-              <label><span>Bottom</span><input id="npBottom" type="number" step="0.625" data-inch-step="0.625"></label>
-              <label><span>Left</span><input id="npLeft" type="number" step="0.625" data-inch-step="0.625"></label>
+            <div class="form-row" data-cols="4">
+              <label class="form-label"><span>Top</span><input id="npTop" class="form-control" type="number" step="0.625" data-inch-step="0.625" /></label>
+              <label class="form-label"><span>Right</span><input id="npRight" class="form-control" type="number" step="0.625" data-inch-step="0.625" /></label>
+              <label class="form-label"><span>Bottom</span><input id="npBottom" class="form-control" type="number" step="0.625" data-inch-step="0.625" /></label>
+              <label class="form-label"><span>Left</span><input id="npLeft" class="form-control" type="number" step="0.625" data-inch-step="0.625" /></label>
             </div>
           </section>
         </div>
       </div>
-      <div class="control-toolbar input-action-toolbar print-hidden">
-        <button class="action-button action-button-primary" id="calcBtn">Update Preview</button>
-        <button class="action-button" id="resetBtn">Reset</button>
-        <span class="text-metric-readout" id="status"></span>
+
+      <div class="form-toolbar layout-cluster print-hidden" data-gap="snug" data-align="between">
+        <div class="layout-cluster" data-gap="snug">
+          <button class="btn btn-primary" id="calcBtn">Update Preview</button>
+          <button class="btn" id="resetBtn">Reset</button>
+        </div>
+        <span class="text-metric" id="status"></span>
       </div>
     </div>
   </div>

--- a/docs/html-partials/templates/tab-perforations-template.html
+++ b/docs/html-partials/templates/tab-perforations-template.html
@@ -10,77 +10,77 @@
 -->
 
 <template id="tab-perforations-template">
-  <div class="finishing-score-pane stack">
-    <div class="finishing-score-layout grid">
-      <div class="finishing-score-column stack">
-        <div class="data-card stack finishing-score-card-intro">
-          <div class="finishing-score-card-title">
+  <div class="finishing-pane layout-stack" data-gap="spacious">
+    <div class="finishing-layout">
+      <div class="finishing-column">
+        <div class="layout-card finishing-card finishing-card--intro">
+          <div class="finishing-card__title layout-stack" data-gap="snug">
             <h3>Perforation Planning</h3>
-            <p class="text-muted-detail">Configure tear-off runs relative to each document before applying them to the layout.</p>
+            <p class="text-muted">Configure tear-off runs relative to each document before applying them to the layout.</p>
           </div>
         </div>
-        <div class="data-card stack finishing-score-card finishing-score-card-vertical">
-          <div class="finishing-score-card-header">
-            <div class="finishing-score-card-title">
+        <div class="layout-card finishing-card">
+          <div class="finishing-card__header">
+            <div class="finishing-card__title layout-stack" data-gap="snug">
               <h3>Vertical Perforations</h3>
-              <p class="text-muted-detail">Lines running top-to-bottom relative to the document width.</p>
+              <p class="text-muted">Lines running top-to-bottom relative to the document width.</p>
             </div>
-            <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical perforation presets">
-              <button class="action-button" id="perfPresetVBifold" type="button">Bifold</button>
-              <button class="action-button" id="perfPresetVTrifold" type="button">Trifold</button>
-              <button class="action-button" id="perfPresetVCustom" type="button">Custom</button>
+            <div class="finishing-preset-group print-hidden" role="group" aria-label="Vertical perforation presets">
+              <button class="btn" id="perfPresetVBifold" type="button">Bifold</button>
+              <button class="btn" id="perfPresetVTrifold" type="button">Trifold</button>
+              <button class="btn" id="perfPresetVCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field stack stack--snug">
-            <label class="finishing-score-label" for="perfV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
+          <div class="finishing-field">
+            <label class="form-label" for="perfV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
               <span>Vertical perforations</span>
-              <input id="perfV" type="text" placeholder="e.g., 0.5" />
+              <input id="perfV" class="form-control" type="text" placeholder="e.g., 0.5" />
             </label>
-            <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
+            <p class="text-muted finishing-hint">Values are relative to the document width.</p>
           </div>
         </div>
-        <div class="data-card stack finishing-score-card finishing-score-card-horizontal">
-          <div class="finishing-score-card-header">
-            <div class="finishing-score-card-title">
+        <div class="layout-card finishing-card">
+          <div class="finishing-card__header">
+            <div class="finishing-card__title layout-stack" data-gap="snug">
               <h3>Horizontal Perforations</h3>
-              <p class="text-muted-detail">Lines running left-to-right relative to the document height.</p>
+              <p class="text-muted">Lines running left-to-right relative to the document height.</p>
             </div>
-            <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal perforation presets">
-              <button class="action-button" id="perfPresetHBifold" type="button">Bifold</button>
-              <button class="action-button" id="perfPresetHTrifold" type="button">Trifold</button>
-              <button class="action-button" id="perfPresetHCustom" type="button">Custom</button>
+            <div class="finishing-preset-group print-hidden" role="group" aria-label="Horizontal perforation presets">
+              <button class="btn" id="perfPresetHBifold" type="button">Bifold</button>
+              <button class="btn" id="perfPresetHTrifold" type="button">Trifold</button>
+              <button class="btn" id="perfPresetHCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field stack stack--snug">
-            <label class="finishing-score-label" for="perfH" title="CSV, 0–1">
+          <div class="finishing-field">
+            <label class="form-label" for="perfH" title="CSV, 0–1">
               <span>Horizontal perforations</span>
-              <input id="perfH" type="text" placeholder="e.g., 0.5" />
+              <input id="perfH" class="form-control" type="text" placeholder="e.g., 0.5" />
             </label>
-            <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
+            <p class="text-muted finishing-hint">Values are relative to the document height.</p>
           </div>
         </div>
-        <div class="data-card finishing-action-card">
-          <div class="control-toolbar finishing-action-toolbar print-hidden">
-            <button class="action-button action-button-primary" id="applyPerforations" type="button">Apply Perforations</button>
-            <span class="text-muted-detail">Leave fields blank to omit perforations.</span>
+        <div class="layout-card finishing-action-card">
+          <div class="form-toolbar layout-cluster finishing-action-bar print-hidden" data-gap="snug" data-align="between">
+            <button class="btn btn-primary" id="applyPerforations" type="button">Apply Perforations</button>
+            <span class="text-muted">Leave fields blank to omit perforations.</span>
           </div>
         </div>
       </div>
-      <div class="finishing-score-column stack finishing-score-results">
-        <div class="finishing-score-results-grid grid grid--auto-fit">
-          <div class="data-card stack finishing-score-table-card">
-            <div>
+      <div class="finishing-column finishing-results">
+        <div class="finishing-table-grid">
+          <div class="layout-card finishing-results">
+            <div class="layout-stack" data-gap="snug">
               <h3>Perforations (Y)</h3>
-              <p class="text-muted-detail">Horizontal perforation runs positioned along the sheet height.</p>
+              <p class="text-muted">Horizontal perforation runs positioned along the sheet height.</p>
             </div>
-            <table class="data-table" id="tblPerforationsH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+            <table class="summary-table" id="tblPerforationsH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
           </div>
-          <div class="data-card stack finishing-score-table-card">
-            <div>
+          <div class="layout-card finishing-results">
+            <div class="layout-stack" data-gap="snug">
               <h3>Perforations (X)</h3>
-              <p class="text-muted-detail">Vertical perforation runs positioned along the sheet width.</p>
+              <p class="text-muted">Vertical perforation runs positioned along the sheet width.</p>
             </div>
-            <table class="data-table" id="tblPerforationsV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+            <table class="summary-table" id="tblPerforationsV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
           </div>
         </div>
       </div>

--- a/docs/html-partials/templates/tab-presets-template.html
+++ b/docs/html-partials/templates/tab-presets-template.html
@@ -9,64 +9,64 @@
 -->
 
 <template id="tab-presets-template">
-  <div class="layout-preset-pane stack">
-    <div class="data-card stack layout-preset-introduction">
+  <div class="layout-stack" data-gap="spacious">
+    <div class="layout-card layout-stack" data-gap="snug">
       <h2>Preset Layouts</h2>
-      <p class="text-muted-detail">
+      <p class="text-muted">
         Jump-start common production setups with one click. Each preset configures sheet, document, gutters, safety areas, and finishing marks to match the listed specification.
       </p>
     </div>
-    <div class="layout-preset-grid grid grid--auto-fit">
-      <div class="data-card stack layout-preset-card">
-        <div class="layout-preset-card-header">
+    <div class="layout-grid" data-gap="relaxed" data-cols="auto" data-min="280">
+      <div class="layout-card layout-stack layout-preset-card" data-gap="snug">
+        <div class="layout-stack" data-gap="snug">
           <h3>Folded Business Card</h3>
-          <p class="text-muted-detail">12×18 sheet, 3.5×5 document, ⅛″ gutters, non-printable margin 1⁄16″.</p>
+          <p class="text-muted">12×18 sheet, 3.5×5 document, ⅛″ gutters, non-printable margin 1⁄16″.</p>
         </div>
         <ul>
           <li>Auto margins enabled</li>
           <li>Horizontal bifold score at 0.5</li>
         </ul>
-        <button class="action-button action-button-primary" data-layout-preset="folded-business-card">Apply preset</button>
+        <button class="btn btn-primary" data-layout-preset="folded-business-card">Apply preset</button>
       </div>
-      <div class="data-card stack layout-preset-card">
-        <div class="layout-preset-card-header">
+      <div class="layout-card layout-stack layout-preset-card" data-gap="snug">
+        <div class="layout-stack" data-gap="snug">
           <h3>Tri-fold Brochure</h3>
-          <p class="text-muted-detail">12×18 sheet, 11×8.5 document, 0.25″ gutters, 0.125″ non-printable area.</p>
+          <p class="text-muted">12×18 sheet, 11×8.5 document, 0.25″ gutters, 0.125″ non-printable area.</p>
         </div>
         <ul>
           <li>Vertical scores at ⅓ and ⅔</li>
         </ul>
-        <button class="action-button action-button-primary" data-layout-preset="trifold-brochure">Apply preset</button>
+        <button class="btn btn-primary" data-layout-preset="trifold-brochure">Apply preset</button>
       </div>
-      <div class="data-card stack layout-preset-card">
-        <div class="layout-preset-card-header">
+      <div class="layout-card layout-stack layout-preset-card" data-gap="snug">
+        <div class="layout-stack" data-gap="snug">
           <h3>Postcard Gang Run</h3>
-          <p class="text-muted-detail">13×19 sheet, 4×6 document, ⅛″ gutters, 0.1″ non-printable area.</p>
+          <p class="text-muted">13×19 sheet, 4×6 document, ⅛″ gutters, 0.1″ non-printable area.</p>
         </div>
         <ul>
           <li>No scores or perforations</li>
         </ul>
-        <button class="action-button action-button-primary" data-layout-preset="postcard-gang-run">Apply preset</button>
+        <button class="btn btn-primary" data-layout-preset="postcard-gang-run">Apply preset</button>
       </div>
-      <div class="data-card stack layout-preset-card">
-        <div class="layout-preset-card-header">
+      <div class="layout-card layout-stack layout-preset-card" data-gap="snug">
+        <div class="layout-stack" data-gap="snug">
           <h3>Event Tickets</h3>
-          <p class="text-muted-detail">12×18 sheet, 2×5.5 document, 0.125″ H / 0.25″ V gutters, 1⁄16″ non-printable.</p>
+          <p class="text-muted">12×18 sheet, 2×5.5 document, 0.125″ H / 0.25″ V gutters, 1⁄16″ non-printable.</p>
         </div>
         <ul>
           <li>Vertical perforation at 0.5</li>
         </ul>
-        <button class="action-button action-button-primary" data-layout-preset="event-tickets">Apply preset</button>
+        <button class="btn btn-primary" data-layout-preset="event-tickets">Apply preset</button>
       </div>
-      <div class="data-card stack layout-preset-card">
-        <div class="layout-preset-card-header">
+      <div class="layout-card layout-stack layout-preset-card" data-gap="snug">
+        <div class="layout-stack" data-gap="snug">
           <h3>Table Tents</h3>
-          <p class="text-muted-detail">13×19 sheet, 5×7 document, 0.25″ gutters, 0.125″ non-printable area.</p>
+          <p class="text-muted">13×19 sheet, 5×7 document, 0.25″ gutters, 0.125″ non-printable area.</p>
         </div>
         <ul>
           <li>Horizontal scores at 0.33 and 0.66</li>
         </ul>
-        <button class="action-button action-button-primary" data-layout-preset="table-tents">Apply preset</button>
+        <button class="btn btn-primary" data-layout-preset="table-tents">Apply preset</button>
       </div>
     </div>
   </div>

--- a/docs/html-partials/templates/tab-print-template.html
+++ b/docs/html-partials/templates/tab-print-template.html
@@ -10,18 +10,17 @@
 -->
 
 <template id="tab-print-template">
-  <div class="print-tab stack stack--spacious">
-    <div class="grid print-layout-grid">
-      <section class="data-card stack print-controls-card">
-        <header class="stack stack--snug">
+  <div class="layout-stack" data-gap="spacious">
+    <div class="layout-grid" data-gap="relaxed" data-cols="auto" data-min="340">
+      <section class="layout-card layout-stack" data-gap="relaxed">
+        <header class="layout-stack" data-gap="snug">
           <h3>Printable Visualizer</h3>
-          <p class="text-muted-detail">
-            Export an accurate 1:1 version of the sheet visualizer. Choose the layers you want, download SVGs, or
-            create a combined PDF package to share or archive.
+          <p class="text-muted">
+            Export an accurate 1:1 version of the sheet visualizer. Choose the layers you want, download SVGs, or create a combined PDF package to share or archive.
           </p>
         </header>
 
-        <dl class="print-summary-grid">
+        <dl class="print-summary">
           <div>
             <dt>Sheet</dt>
             <dd id="printSheetSummary">—</dd>
@@ -44,79 +43,72 @@
           </div>
         </dl>
 
-        <fieldset class="print-layer-selector">
+        <fieldset class="layout-card layout-stack" data-gap="snug">
           <legend>Include layers</legend>
-          <div class="print-layer-options">
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="sheet" checked />
-              <span>Sheet outline</span>
+          <div class="layout-grid" data-gap="snug" data-cols="auto" data-min="180">
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="sheet" checked />
+              <span class="form-choice__label">Sheet outline</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="nonPrintable" checked />
-              <span>Non-printable &amp; printable border</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="nonPrintable" checked />
+              <span class="form-choice__label">Non-printable &amp; printable border</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="layout" checked />
-              <span>Layout area</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="layout" checked />
+              <span class="form-choice__label">Layout area</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="docs" checked />
-              <span>Documents</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="docs" checked />
+              <span class="form-choice__label">Documents</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="cuts" checked />
-              <span>Cuts</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="cuts" checked />
+              <span class="form-choice__label">Cuts</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="slits" checked />
-              <span>Slits</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="slits" checked />
+              <span class="form-choice__label">Slits</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="scores" checked />
-              <span>Scores</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="scores" checked />
+              <span class="form-choice__label">Scores</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="perforations" checked />
-              <span>Perforations</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="perforations" checked />
+              <span class="form-choice__label">Perforations</span>
             </label>
-            <label class="print-layer-option">
-              <input type="checkbox" class="print-layer-toggle" data-layer="holes" checked />
-              <span>Holes</span>
+            <label class="form-choice">
+              <input type="checkbox" class="form-choice__control print-layer-toggle" data-layer="holes" checked />
+              <span class="form-choice__label">Holes</span>
             </label>
           </div>
         </fieldset>
 
-        <div class="print-actions stack stack--tight">
-          <div class="print-action-row">
-            <button type="button" class="action-button action-button-primary" id="printDownloadPdf" disabled>
-              Export 2-page PDF
-            </button>
-            <button type="button" class="action-button" id="printOpenPrintDialog" disabled>
-              Open print dialog
-            </button>
+        <div class="layout-stack" data-gap="snug">
+          <div class="layout-cluster" data-gap="snug">
+            <button type="button" class="btn btn-primary" id="printDownloadPdf" disabled>Export 2-page PDF</button>
+            <button type="button" class="btn" id="printOpenPrintDialog" disabled>Open print dialog</button>
           </div>
-          <div class="print-action-row">
-            <button type="button" class="action-button" id="printDownloadSvg" disabled>Download layout SVG</button>
-            <button type="button" class="action-button" id="printDownloadLayoutDetails" disabled>
-              Download layout details SVG
-            </button>
+          <div class="layout-cluster" data-gap="snug">
+            <button type="button" class="btn" id="printDownloadSvg" disabled>Download layout SVG</button>
+            <button type="button" class="btn" id="printDownloadLayoutDetails" disabled>Download layout details SVG</button>
           </div>
-          <p class="print-actions-hint text-muted-detail">
+          <p class="text-muted">
             The PDF includes the visualizer and the detailed program sheet on separate pages sized to the selected sheet.
           </p>
         </div>
       </section>
 
-      <section class="data-card stack print-preview-card">
-        <div class="print-preview-stage measurement-theme" id="printPreviewStage" aria-live="polite">
-          <div class="print-preview-empty">
+      <section class="layout-card layout-stack" data-gap="snug">
+        <div class="layout-card print-stage viz-theme" id="printPreviewStage" aria-live="polite">
+          <div class="layout-stack" data-gap="snug">
             <p>The printable visualizer is ready once a layout is calculated.</p>
             <p>Adjust inputs on the other tabs, then return here to export.</p>
           </div>
         </div>
-        <p class="text-muted-detail">
-          The preview uses physical measurements (<code>in</code>/<code>mm</code>) so it may be larger than the screen.
-          Use your browser zoom controls to inspect details, but exported files always stay at 100% scale.
+        <p class="text-muted">
+          The preview uses physical measurements (<code>in</code>/<code>mm</code>) so it may be larger than the screen. Use your browser zoom controls to inspect details, but exported files always stay at 100% scale.
         </p>
       </section>
     </div>

--- a/docs/html-partials/templates/tab-program-sequence-template.html
+++ b/docs/html-partials/templates/tab-program-sequence-template.html
@@ -1,7 +1,6 @@
 <!--
   Load timing:
-    - Hydrated into #tab-program-sequence by the tab registry when the Program
-      Sequence tab is registered or activated.
+    - Hydrated into #tab-program-sequence by the tab registry when the Program Sequence tab is registered or activated.
   Key selectors:
     - #tblProgramSequence tbody receives measurement rows via fillTable.
   JS dependencies:
@@ -9,9 +8,9 @@
 -->
 
 <template id="tab-program-sequence-template">
-  <div class="data-card">
+  <div class="layout-card layout-stack" data-gap="snug">
     <h3>Program Sequence</h3>
-    <table class="data-table" id="tblProgramSequence">
+    <table class="summary-table" id="tblProgramSequence">
       <thead>
         <tr><th>Step</th><th>in</th><th>mm</th></tr>
       </thead>

--- a/docs/html-partials/templates/tab-scores-template.html
+++ b/docs/html-partials/templates/tab-scores-template.html
@@ -4,85 +4,85 @@
   Key selectors:
     - Preset buttons (#scorePresetBifold, #scorePresetTrifold, #scorePresetCustom, #scorePresetHBifold, #scorePresetHTrifold, #scorePresetHCustom).
     - Offset inputs #scoresV and #scoresH plus result tables #tblScoresH and #tblScoresV.
-    - Action buttons #swapScoreOffsets and #applyScores inside .finishing-score-toolbar areas.
+    - Action buttons #swapScoreOffsets and #applyScores inside .finishing-action-bar areas.
   JS dependencies:
     - docs/js/tabs/scores.js wires preset toggles, input listeners, swap/apply handlers, and fills measurement tables.
     - docs/js/utils/dom.js utilities assist with table population and measurement hover/selection behavior.
 -->
 
 <template id="tab-scores-template">
-  <div class="finishing-score-pane stack">
-    <div class="finishing-score-layout grid">
-      <div class="finishing-score-column stack">
-        <div class="data-card stack finishing-score-card-intro">
-          <div class="finishing-score-card-title">
+  <div class="finishing-pane layout-stack" data-gap="spacious">
+    <div class="finishing-layout">
+      <div class="finishing-column">
+        <div class="layout-card finishing-card finishing-card--intro">
+          <div class="finishing-card__title layout-stack" data-gap="snug">
             <h3>Score Planning</h3>
-            <p class="text-muted-detail">Scores are normalized to each document. Use a preset for common folds or switch to custom entry to fine-tune the layout.</p>
+            <p class="text-muted">Scores are normalized to each document. Use a preset for common folds or switch to custom entry to fine-tune the layout.</p>
           </div>
         </div>
-        <div class="data-card stack finishing-score-card finishing-score-card-vertical">
-          <div class="finishing-score-card-header">
-            <div class="finishing-score-card-title">
+        <div class="layout-card finishing-card">
+          <div class="finishing-card__header">
+            <div class="finishing-card__title layout-stack" data-gap="snug">
               <h3>Vertical Scores</h3>
-              <p class="text-muted-detail">Set positions for lines that run top-to-bottom across the sheet relative to the document width.</p>
+              <p class="text-muted">Set positions for lines that run top-to-bottom across the sheet relative to the document width.</p>
             </div>
-            <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Vertical score presets">
-              <button class="action-button" id="scorePresetBifold" type="button">Bifold</button>
-              <button class="action-button" id="scorePresetTrifold" type="button">Trifold</button>
-              <button class="action-button" id="scorePresetCustom" type="button">Custom</button>
+            <div class="finishing-preset-group print-hidden" role="group" aria-label="Vertical score presets">
+              <button class="btn" id="scorePresetBifold" type="button">Bifold</button>
+              <button class="btn" id="scorePresetTrifold" type="button">Trifold</button>
+              <button class="btn" id="scorePresetCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field stack stack--snug">
-            <label class="finishing-score-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
+          <div class="finishing-field">
+            <label class="form-label" for="scoresV" title="CSV, 0–1 (e.g., 0.5 or 0.33,0.66)">
               <span>Vertical scores</span>
-              <input id="scoresV" type="text" placeholder="e.g., 0.5" />
+              <input id="scoresV" class="form-control" type="text" placeholder="e.g., 0.5" />
             </label>
-            <p class="text-muted-detail finishing-score-hint">Values are relative to the document width.</p>
+            <p class="text-muted finishing-hint">Values are relative to the document width.</p>
           </div>
         </div>
-        <div class="data-card stack finishing-score-card finishing-score-card-horizontal">
-          <div class="finishing-score-card-header">
-            <div class="finishing-score-card-title">
+        <div class="layout-card finishing-card">
+          <div class="finishing-card__header">
+            <div class="finishing-card__title layout-stack" data-gap="snug">
               <h3>Horizontal Scores</h3>
-              <p class="text-muted-detail">Set positions for lines that run left-to-right across the sheet relative to the document height.</p>
+              <p class="text-muted">Set positions for lines that run left-to-right across the sheet relative to the document height.</p>
             </div>
-            <div class="finishing-score-preset-group print-hidden" role="group" aria-label="Horizontal score presets">
-              <button class="action-button" id="scorePresetHBifold" type="button">Bifold</button>
-              <button class="action-button" id="scorePresetHTrifold" type="button">Trifold</button>
-              <button class="action-button" id="scorePresetHCustom" type="button">Custom</button>
+            <div class="finishing-preset-group print-hidden" role="group" aria-label="Horizontal score presets">
+              <button class="btn" id="scorePresetHBifold" type="button">Bifold</button>
+              <button class="btn" id="scorePresetHTrifold" type="button">Trifold</button>
+              <button class="btn" id="scorePresetHCustom" type="button">Custom</button>
             </div>
           </div>
-          <div class="finishing-score-field stack stack--snug">
-            <label class="finishing-score-label" for="scoresH" title="CSV, 0–1">
+          <div class="finishing-field">
+            <label class="form-label" for="scoresH" title="CSV, 0–1">
               <span>Horizontal scores</span>
-              <input id="scoresH" type="text" placeholder="e.g., 0.5" />
+              <input id="scoresH" class="form-control" type="text" placeholder="e.g., 0.5" />
             </label>
-            <p class="text-muted-detail finishing-score-hint">Values are relative to the document height.</p>
+            <p class="text-muted finishing-hint">Values are relative to the document height.</p>
           </div>
         </div>
-        <div class="data-card finishing-action-card">
-          <div class="control-toolbar finishing-action-toolbar print-hidden">
-            <button class="action-button" id="swapScoreOffsets" type="button">Swap vertical ↔ horizontal scores</button>
-            <button class="action-button action-button-primary" id="applyScores" type="button">Apply Scores</button>
-            <span class="text-muted-detail">Leave fields blank to omit scores.</span>
+        <div class="layout-card drilling-action-card">
+          <div class="form-toolbar layout-cluster finishing-action-bar print-hidden" data-gap="snug" data-align="between">
+            <button class="btn" id="swapScoreOffsets" type="button">Swap vertical ↔ horizontal scores</button>
+            <button class="btn btn-primary" id="applyScores" type="button">Apply Scores</button>
+            <span class="text-muted">Leave fields blank to omit scores.</span>
           </div>
         </div>
       </div>
-      <div class="finishing-score-column stack finishing-score-results">
-        <div class="finishing-score-results-grid grid grid--auto-fit">
-          <div class="data-card stack finishing-score-table-card">
-            <div>
+      <div class="finishing-column finishing-results">
+        <div class="finishing-table-grid">
+          <div class="layout-card finishing-results">
+            <div class="layout-stack" data-gap="snug">
               <h3>Scores (Y)</h3>
-              <p class="text-muted-detail">Horizontal runs positioned along the sheet height.</p>
+              <p class="text-muted">Horizontal runs positioned along the sheet height.</p>
             </div>
-            <table class="data-table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+            <table class="summary-table" id="tblScoresH"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
           </div>
-          <div class="data-card stack finishing-score-table-card">
-            <div>
+          <div class="layout-card finishing-results">
+            <div class="layout-stack" data-gap="snug">
               <h3>Scores (X)</h3>
-              <p class="text-muted-detail">Vertical runs positioned along the sheet width.</p>
+              <p class="text-muted">Vertical runs positioned along the sheet width.</p>
             </div>
-            <table class="data-table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
+            <table class="summary-table" id="tblScoresV"><thead><tr><th>Label</th><th>in</th><th>mm</th></tr></thead><tbody></tbody></table>
           </div>
         </div>
       </div>

--- a/docs/html-partials/templates/tab-summary-template.html
+++ b/docs/html-partials/templates/tab-summary-template.html
@@ -2,176 +2,170 @@
   Load timing:
     - Cloned into #tab-summary by docs/js/tabs/registry.hydrateTabPanel('summary') after templates load during bootstrap.
   Key selectors:
-    - .summary-metrics-grid container and spans #vAcross, #vDown, #vTotal, #vLayout, #vOrigin, #vRealMargins, #vUsed, #vTrail.
+    - Metrics spans (#vAcross, #vDown, #vTotal, #vLayout, #vOrigin, #vRealMargins, #vUsed, #vTrail).
   JS dependencies:
     - docs/js/tabs/summary.js writes calculated metrics into the spans on activation/registration.
     - docs/js/app.js feeds formatted measurement strings used by the summary module for display updates.
 -->
 
 <template id="tab-summary-template">
-  <div class="summary-metrics-grid">
-    <article class="data-card summary-card">
-      <h3 class="summary-card__title">Counts</h3>
-      <dl class="summary-card__metrics">
+  <div class="summary-grid">
+    <article class="layout-card summary-card">
+      <h3>Counts</h3>
+      <dl class="summary-metrics">
         <div>
           <dt>Across</dt>
-          <dd class="summary-metric-value" id="vAcross">—</dd>
+          <dd class="text-metric" id="vAcross">—</dd>
         </div>
         <div>
           <dt>Down</dt>
-          <dd class="summary-metric-value" id="vDown">—</dd>
+          <dd class="text-metric" id="vDown">—</dd>
         </div>
         <div>
           <dt>Total</dt>
-          <dd class="summary-metric-value" id="vTotal">—</dd>
+          <dd class="text-metric" id="vTotal">—</dd>
         </div>
       </dl>
     </article>
-    <article class="data-card summary-card">
-      <h3 class="summary-card__title">Layout Area</h3>
-      <dl class="summary-card__metrics">
+    <article class="layout-card summary-card">
+      <h3>Layout Area</h3>
+      <dl class="summary-metrics">
         <div>
           <dt>W × H</dt>
-          <dd class="summary-metric-value" id="vLayout">—</dd>
+          <dd class="text-metric" id="vLayout">—</dd>
         </div>
         <div>
           <dt>Origin</dt>
-          <dd class="summary-metric-value" id="vOrigin">—</dd>
+          <dd class="text-metric" id="vOrigin">—</dd>
         </div>
         <div>
           <dt>Realized Margins</dt>
-          <dd class="summary-metric-value" id="vRealMargins">—</dd>
+          <dd class="text-metric" id="vRealMargins">—</dd>
         </div>
       </dl>
     </article>
-    <article class="data-card summary-card">
-      <h3 class="summary-card__title">Utilization</h3>
-      <dl class="summary-card__metrics">
+    <article class="layout-card summary-card">
+      <h3>Utilization</h3>
+      <dl class="summary-metrics">
         <div>
           <dt>Used W/H</dt>
-          <dd class="summary-metric-value" id="vUsed">—</dd>
+          <dd class="text-metric" id="vUsed">—</dd>
         </div>
         <div>
           <dt>Trailing W/H</dt>
-          <dd class="summary-metric-value" id="vTrail">—</dd>
+          <dd class="text-metric" id="vTrail">—</dd>
         </div>
       </dl>
     </article>
   </div>
 
-  <section class="summary-calculator-section" aria-label="Production calculators">
-    <div class="summary-calculator-grid">
-      <article class="data-card summary-calculator" data-calculator="pad">
-        <header class="summary-calculator__header">
-          <h3 class="summary-calculator__title">Pad Calculator</h3>
-          <p class="summary-calculator__description">
-            Work out how many press sheets you need to build padded sets.
-          </p>
+  <section class="layout-stack" data-gap="relaxed" aria-label="Production calculators">
+    <div class="layout-grid" data-gap="relaxed" data-cols="auto" data-min="280">
+      <article class="layout-card layout-stack summary-calculator" data-gap="snug" data-calculator="pad">
+        <header class="layout-stack" data-gap="snug">
+          <h3>Pad Calculator</h3>
+          <p class="text-muted">Work out how many press sheets you need to build padded sets.</p>
         </header>
-        <form class="summary-calculator__form" autocomplete="off">
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">Number of pads</span>
-            <input type="number" inputmode="numeric" min="0" step="1" id="padCount" placeholder="0" />
+        <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
+          <label class="form-label summary-calculator__field">
+            <span>Number of pads</span>
+            <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="padCount" placeholder="0" />
           </label>
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">Sheets per pad</span>
-            <input type="number" inputmode="numeric" min="1" step="1" id="padSheets" value="50" />
-            <span class="summary-calculator__hint">Defaulted to 50 finished sheets per pad.</span>
+          <label class="form-label summary-calculator__field">
+            <span>Sheets per pad</span>
+            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="padSheets" value="50" />
+            <span class="text-muted summary-calculator__hint">Defaulted to 50 finished sheets per pad.</span>
           </label>
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">N-up (per press sheet)</span>
-            <input type="number" inputmode="numeric" min="1" step="1" id="padNUp" />
-            <span class="summary-calculator__hint">Auto-fills from the current layout.</span>
+          <label class="form-label summary-calculator__field">
+            <span>N-up (per press sheet)</span>
+            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="padNUp" />
+            <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
           </label>
         </form>
-        <dl class="summary-calculator__results" aria-live="polite">
+        <dl class="summary-calculator__results summary-metrics" aria-live="polite">
           <div>
             <dt>Finished pieces</dt>
-            <dd id="padTotalPieces">—</dd>
+            <dd class="text-metric" id="padTotalPieces">—</dd>
           </div>
           <div>
             <dt>Press sheets to print</dt>
-            <dd id="padTotalSheets">—</dd>
+            <dd class="text-metric" id="padTotalSheets">—</dd>
           </div>
           <div>
             <dt>Overage after padding</dt>
-            <dd id="padRemainder">—</dd>
+            <dd class="text-metric" id="padRemainder">—</dd>
           </div>
         </dl>
       </article>
 
-      <article class="data-card summary-calculator" data-calculator="run">
-        <header class="summary-calculator__header">
-          <h3 class="summary-calculator__title">Target Quantity Planner</h3>
-          <p class="summary-calculator__description">
-            Start from a desired finished quantity and include spoilage/overs.
-          </p>
+      <article class="layout-card layout-stack summary-calculator" data-gap="snug" data-calculator="run">
+        <header class="layout-stack" data-gap="snug">
+          <h3>Target Quantity Planner</h3>
+          <p class="text-muted">Start from a desired finished quantity and include spoilage/overs.</p>
         </header>
-        <form class="summary-calculator__form" autocomplete="off">
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">Desired finished pieces</span>
-            <input type="number" inputmode="numeric" min="0" step="1" id="runDesired" placeholder="0" />
+        <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
+          <label class="form-label summary-calculator__field">
+            <span>Desired finished pieces</span>
+            <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="runDesired" placeholder="0" />
           </label>
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">N-up (per press sheet)</span>
-            <input type="number" inputmode="numeric" min="1" step="1" id="runNUp" />
-            <span class="summary-calculator__hint">Auto-fills from the current layout.</span>
+          <label class="form-label summary-calculator__field">
+            <span>N-up (per press sheet)</span>
+            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="runNUp" />
+            <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
           </label>
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">Spoilage / overs (%)</span>
-            <input type="number" inputmode="decimal" min="0" step="0.1" id="runOvers" value="0" />
+          <label class="form-label summary-calculator__field">
+            <span>Spoilage / overs (%)</span>
+            <input class="form-control" type="number" inputmode="decimal" min="0" step="0.1" id="runOvers" value="0" />
           </label>
         </form>
-        <dl class="summary-calculator__results" aria-live="polite">
+        <dl class="summary-calculator__results summary-metrics" aria-live="polite">
           <div>
             <dt>Finished pieces with overs</dt>
-            <dd id="runTotalPieces">—</dd>
+            <dd class="text-metric" id="runTotalPieces">—</dd>
           </div>
           <div>
             <dt>Press sheets to print</dt>
-            <dd id="runTotalSheets">—</dd>
+            <dd class="text-metric" id="runTotalSheets">—</dd>
           </div>
           <div>
             <dt>Overs (pieces / sheets)</dt>
-            <dd id="runOversBreakdown">—</dd>
+            <dd class="text-metric" id="runOversBreakdown">—</dd>
           </div>
         </dl>
       </article>
 
-      <article class="data-card summary-calculator" data-calculator="sheets">
-        <header class="summary-calculator__header">
-          <h3 class="summary-calculator__title">Sheets to Pads Converter</h3>
-          <p class="summary-calculator__description">
-            Translate a press run into finished pieces and pad counts.
-          </p>
+      <article class="layout-card layout-stack summary-calculator" data-gap="snug" data-calculator="sheets">
+        <header class="layout-stack" data-gap="snug">
+          <h3>Sheets to Pads Converter</h3>
+          <p class="text-muted">Translate a press run into finished pieces and pad counts.</p>
         </header>
-        <form class="summary-calculator__form" autocomplete="off">
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">Press sheets to run</span>
-            <input type="number" inputmode="numeric" min="0" step="1" id="sheetRun" placeholder="0" />
+        <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
+          <label class="form-label summary-calculator__field">
+            <span>Press sheets to run</span>
+            <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="sheetRun" placeholder="0" />
           </label>
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">N-up (per press sheet)</span>
-            <input type="number" inputmode="numeric" min="1" step="1" id="sheetNUp" />
-            <span class="summary-calculator__hint">Auto-fills from the current layout.</span>
+          <label class="form-label summary-calculator__field">
+            <span>N-up (per press sheet)</span>
+            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="sheetNUp" />
+            <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
           </label>
-          <label class="summary-calculator__field">
-            <span class="summary-calculator__label">Finished pieces per pad</span>
-            <input type="number" inputmode="numeric" min="1" step="1" id="sheetPerPad" value="50" />
+          <label class="form-label summary-calculator__field">
+            <span>Finished pieces per pad</span>
+            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="sheetPerPad" value="50" />
           </label>
         </form>
-        <dl class="summary-calculator__results" aria-live="polite">
+        <dl class="summary-calculator__results summary-metrics" aria-live="polite">
           <div>
             <dt>Total finished pieces</dt>
-            <dd id="sheetTotalPieces">—</dd>
+            <dd class="text-metric" id="sheetTotalPieces">—</dd>
           </div>
           <div>
             <dt>Complete pads</dt>
-            <dd id="sheetTotalPads">—</dd>
+            <dd class="text-metric" id="sheetTotalPads">—</dd>
           </div>
           <div>
             <dt>Leftover pieces</dt>
-            <dd id="sheetPadRemainder">—</dd>
+            <dd class="text-metric" id="sheetPadRemainder">—</dd>
           </div>
         </dl>
       </article>

--- a/docs/html-partials/templates/tab-warnings-template.html
+++ b/docs/html-partials/templates/tab-warnings-template.html
@@ -2,15 +2,15 @@
   Load timing:
     - Cloned into #tab-warnings when docs/js/tabs/registry.hydrateTabPanel('warnings') executes during the tab module bootstrap.
   Key selectors:
-    - .data-card layout wrapper used for spacing, with no interactive IDs yet.
+    - Layout card wrapper used for spacing, with no interactive IDs yet.
   JS dependencies:
     - docs/js/tabs/warnings.js currently hydrates only to mark readiness; future warning injections should target this card body.
 -->
 
 <template id="tab-warnings-template">
-  <div class="data-card stack">
+  <div class="layout-card layout-stack" data-gap="snug">
     <h2>Warnings</h2>
-    <p class="text-muted-detail">Production notes and layout warnings will appear here in a future update.</p>
-    <p class="text-muted-detail">For now, use this space to track manual adjustments or finishing considerations that fall outside the presets.</p>
+    <p class="text-muted">Production notes and layout warnings will appear here in a future update.</p>
+    <p class="text-muted">For now, use this space to track manual adjustments or finishing considerations that fall outside the presets.</p>
   </div>
 </template>

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,18 +10,18 @@
     <link rel="stylesheet" href="./css/style.css" />
   </head>
   <body>
-    <div class="layout-app-shell stack">
+    <div class="layout-shell layout-stack" data-gap="spacious">
       <!-- Fragment placeholder: App header -->
       <div data-partial="app-header"></div>
 
       <!-- Fragment placeholder: Sheet preview visualizer -->
       <div data-partial="visualizer"></div>
 
-      <main class="content-section output-details-section stack">
+      <main class="layout-panel layout-stack summary-shell" data-gap="cozy">
         <!-- Fragment placeholder: Output tab navigation -->
         <div data-partial="tab-nav"></div>
 
-        <div class="output-tabpanel-collection">
+        <div class="tabs-panels" data-role="tabs-panels">
           <section id="tab-inputs" class="is-active" data-tab-template="tab-inputs-template"></section>
           <section id="tab-presets" data-tab-template="tab-presets-template"></section>
           <section id="tab-summary" data-tab-template="tab-summary-template"></section>

--- a/docs/js/tabs/drilling.js
+++ b/docs/js/tabs/drilling.js
@@ -122,7 +122,7 @@ const updateAlignOptions = (select, edge, selected) => {
 
 const createFieldLabel = (text) => {
   const label = document.createElement('label');
-  label.className = 'finishing-score-label';
+  label.className = 'form-label';
   const span = document.createElement('span');
   span.textContent = text;
   label.appendChild(span);
@@ -131,7 +131,7 @@ const createFieldLabel = (text) => {
 
 const createHint = (text) => {
   const hint = document.createElement('p');
-  hint.className = 'text-muted-detail';
+  hint.className = 'text-muted';
   hint.textContent = text;
   return hint;
 };
@@ -167,6 +167,7 @@ const createLocationRow = (entry) => {
 
   const edgeLabel = createFieldLabel('Edge');
   const edgeSelect = document.createElement('select');
+  edgeSelect.className = 'form-select';
   edgeSelect.dataset.role = 'edge';
   EDGE_OPTIONS.forEach((opt) => {
     const option = createOption(opt.value, opt.label);
@@ -178,18 +179,21 @@ const createLocationRow = (entry) => {
 
   const alignLabel = createFieldLabel('Alignment');
   const alignSelect = document.createElement('select');
+  alignSelect.className = 'form-select';
   alignSelect.dataset.role = 'align';
   updateAlignOptions(alignSelect, entry.edge, entry.align);
   alignLabel.appendChild(alignSelect);
   row.appendChild(alignLabel);
 
   const axisWrapper = document.createElement('div');
-  axisWrapper.className = 'stack stack--snug';
+  axisWrapper.className = 'layout-stack';
+  axisWrapper.dataset.gap = 'snug';
   const axisLabel = createFieldLabel('Along-edge offset (in)');
   const axisInput = document.createElement('input');
   axisInput.type = 'number';
   axisInput.step = '0.01';
   axisInput.value = String(entry.axisOffset ?? 0);
+  axisInput.className = 'form-control';
   axisInput.dataset.role = 'axis-offset';
   axisLabel.appendChild(axisInput);
   axisWrapper.appendChild(axisLabel);
@@ -197,13 +201,15 @@ const createLocationRow = (entry) => {
   row.appendChild(axisWrapper);
 
   const offsetWrapper = document.createElement('div');
-  offsetWrapper.className = 'stack stack--snug';
+  offsetWrapper.className = 'layout-stack';
+  offsetWrapper.dataset.gap = 'snug';
   const offsetLabel = createFieldLabel('Edge offset (in)');
   const offsetInput = document.createElement('input');
   offsetInput.type = 'number';
   offsetInput.step = '0.01';
   offsetInput.min = '0';
   offsetInput.value = String(entry.offset ?? 0);
+  offsetInput.className = 'form-control';
   offsetInput.dataset.role = 'offset';
   offsetLabel.appendChild(offsetInput);
   offsetWrapper.appendChild(offsetLabel);
@@ -212,7 +218,7 @@ const createLocationRow = (entry) => {
 
   const removeButton = document.createElement('button');
   removeButton.type = 'button';
-  removeButton.className = 'action-button action-button-ghost drilling-remove-location';
+  removeButton.className = 'btn btn-ghost drilling-remove-location';
   removeButton.dataset.role = 'remove';
   removeButton.textContent = 'Remove';
   row.appendChild(removeButton);

--- a/docs/js/tabs/registry.js
+++ b/docs/js/tabs/registry.js
@@ -7,7 +7,7 @@ let isInitialized = false;
 
 const getTabTrigger = (key) =>
   typeof document !== 'undefined'
-    ? document.querySelector(`.output-tab-trigger[data-tab='${key}']`)
+    ? document.querySelector(`.tabs-trigger[data-tab='${key}']`)
     : null;
 const getTabPanel = (key) => (typeof document !== 'undefined' ? document.querySelector(`#tab-${key}`) : null);
 const hydratedPanels = new Set();
@@ -52,7 +52,7 @@ const resolveTabElements = (preferredKey) => {
   if (fallbackTrigger && fallbackPanel) {
     return { key: fallbackTabKey, trigger: fallbackTrigger, panel: fallbackPanel };
   }
-  const firstTrigger = typeof document !== 'undefined' ? document.querySelector('.output-tab-trigger') : null;
+  const firstTrigger = typeof document !== 'undefined' ? document.querySelector('.tabs-trigger') : null;
   if (firstTrigger) {
     const firstKey = firstTrigger.dataset.tab;
     const firstPanel = getTabPanel(firstKey);
@@ -84,8 +84,8 @@ export function activateTab(targetKey) {
   }
 
   if (typeof document !== 'undefined') {
-    document.querySelectorAll('.output-tab-trigger').forEach((el) => el.classList.remove('is-active'));
-    document.querySelectorAll('.output-tabpanel-collection>section').forEach((el) => el.classList.remove('is-active'));
+    document.querySelectorAll('.tabs-trigger').forEach((el) => el.classList.remove('is-active'));
+    document.querySelectorAll('.tabs-panels>section').forEach((el) => el.classList.remove('is-active'));
   }
 
   trigger.classList.add('is-active');
@@ -106,14 +106,14 @@ export function initializeTabRegistry(options = {}) {
   }
 
   if (!isInitialized && typeof document !== 'undefined') {
-    document.querySelectorAll('.output-tab-trigger').forEach((trigger) => {
+    document.querySelectorAll('.tabs-trigger').forEach((trigger) => {
       trigger.addEventListener('click', () => activateTab(trigger.dataset.tab));
     });
     isInitialized = true;
   }
 
   const initiallyActive = typeof document !== 'undefined'
-    ? document.querySelector('.output-tab-trigger.is-active')
+    ? document.querySelector('.tabs-trigger.is-active')
     : null;
   const initialKey = initiallyActive?.dataset?.tab ?? fallbackTabKey;
   activateTab(initialKey);

--- a/docs/js/tabs/summary.js
+++ b/docs/js/tabs/summary.js
@@ -9,7 +9,7 @@ function init() {
   hydrateTabPanel(TAB_KEY);
   initializeSummaryCalculators();
   if (initialized) return;
-  $$('.layer-visibility-toggle-input').forEach((input) => {
+  $$('.viz-layer-input').forEach((input) => {
     const layer = input.dataset.layer;
     if (!layer) return;
     const initial = getLayerVisibility(layer);

--- a/docs/js/utils/dom.js
+++ b/docs/js/utils/dom.js
@@ -110,7 +110,7 @@ export const fillTable = (tbody, rows, type = 'measure') => {
         `<td class="k">${row.inches.toFixed(3)}</td>`,
         `<td class="k">${row.millimeters.toFixed(2)}</td>`,
       ];
-      return `<tr class="measurement-row" data-measure-id="${id}" data-measure-type="${type}" data-measure-index="${index}">${cells.join('')}</tr>`;
+      return `<tr class="viz-measure-row" data-measure-id="${id}" data-measure-type="${type}" data-measure-index="${index}">${cells.join('')}</tr>`;
     })
     .join('');
   tbody.querySelectorAll('tr[data-measure-id]').forEach((row) => {
@@ -141,7 +141,7 @@ export const fillHoleTable = (tbody, holes = []) => {
         `<td class="k">${inchesToMillimeters(y).toFixed(2)}</td>`,
         `<td class="k">${inchesToMillimeters(diameter).toFixed(2)}</td>`,
       ];
-      return `<tr class="measurement-row" data-measure-id="${id}" data-measure-type="hole" data-measure-index="${index}">${cells.join('')}</tr>`;
+      return `<tr class="viz-measure-row" data-measure-id="${id}" data-measure-type="hole" data-measure-index="${index}">${cells.join('')}</tr>`;
     })
     .join('');
   tbody.querySelectorAll('tr[data-measure-id]').forEach((row) => {


### PR DESCRIPTION
## Summary
- rebuild the calculator CSS around shared design tokens, layout utilities, and refreshed control/visualizer styling
- align the HTML tab templates and supporting JS modules with the new layout-, form-, btn-, and viz- class conventions
- update the brand guidelines with the current tokens, component examples, and legacy-to-modern migration map

## Testing
- npm test
- wc -c docs/css/*.css docs/css/tabs/*.css

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d737d69f88324a8d3f71ced2d5ed8)