### PR TITLE
Add header unit toggle and update imperial celebration

### DIFF
--- a/docs/css/celebration.css
+++ b/docs/css/celebration.css
@@ -56,6 +56,52 @@
   animation: freedom-alert-fade 3.5s ease-in-out forwards;
 }
 
+.freedom-confetti {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 9998;
+}
+
+.freedom-confetti__piece {
+  position: absolute;
+  top: -10vh;
+  inline-size: 12px;
+  block-size: 18px;
+  border-radius: 4px;
+  background: var(--confetti-color, #ffffff);
+  transform: translate3d(var(--confetti-x-start, 0), -10vh, 0) rotate(0deg) scale(var(--confetti-scale, 1));
+  animation: freedom-confetti-fall var(--confetti-duration, 4s) ease-in forwards;
+  animation-delay: var(--confetti-delay, 0s);
+  opacity: 0.9;
+}
+
+.freedom-confetti__piece::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: inherit;
+  transform: rotate(45deg);
+  opacity: 0.35;
+}
+
+@keyframes freedom-confetti-fall {
+  0% {
+    transform: translate3d(var(--confetti-x-start, 0), -12vh, 0) rotate(0deg) scale(var(--confetti-scale, 1));
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--confetti-x-end, 0), 110vh, 0)
+      rotate(var(--confetti-rotation, 540deg))
+      scale(var(--confetti-scale, 1));
+    opacity: 0;
+  }
+}
+
 @keyframes freedom-alert-fade {
   0% {
     opacity: 0;

--- a/docs/css/controls.css
+++ b/docs/css/controls.css
@@ -187,6 +187,51 @@ input[type="number"].form-control { text-align: right; }
   font-size: 1rem;
 }
 
+.units-toggle {
+  border-radius: 999px;
+  padding: var(--space-2) var(--space-4);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-width: 2px;
+  gap: var(--space-2);
+}
+
+.units-toggle span[data-role='units-toggle-abbr'] {
+  font-size: 0.75em;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.units-toggle[data-system='imperial'] {
+  background: linear-gradient(135deg, rgba(178, 34, 52, 0.92), rgba(60, 59, 110, 0.92));
+  border-color: rgba(60, 59, 110, 0.85);
+  color: #f9fafb;
+  box-shadow: 0 12px 26px rgba(60, 59, 110, 0.28);
+}
+
+.units-toggle[data-system='imperial'] span[data-role='units-toggle-abbr'] {
+  color: rgba(255, 255, 255, 0.85);
+  opacity: 1;
+}
+
+.units-toggle[data-system='metric'] {
+  background: var(--color-surface-2);
+  color: var(--color-text-secondary);
+}
+
+.units-toggle[data-system='metric']:hover,
+.units-toggle[data-system='metric']:focus-visible {
+  color: var(--color-text-primary);
+}
+
+.units-toggle[data-system='imperial']:hover,
+.units-toggle[data-system='imperial']:focus-visible {
+  background: linear-gradient(135deg, rgba(178, 34, 52, 1), rgba(60, 59, 110, 1));
+  color: #ffffff;
+}
+
 /* ---- Tabs ---- */
 .tabs-nav {
   border-bottom: 1px solid var(--color-border);

--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -52,7 +52,18 @@ th { color: var(--color-text-secondary); font-weight: 500; letter-spacing: 0.02e
   gap: var(--space-5);
 }
 
-.layout-header { max-width: 720px; margin: 0 auto; }
+.layout-header {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.layout-header h1 {
+  text-align: left;
+}
+
+.layout-header .text-muted {
+  max-width: 38ch;
+}
 
 
 .layout-panel {

--- a/docs/html-partials/fragments/app-header.html
+++ b/docs/html-partials/fragments/app-header.html
@@ -10,6 +10,22 @@
       once the fragment loader swaps it in.
 -->
 <header class="layout-header layout-stack" data-gap="snug">
-  <h1>Kevin’s Bitchin’ Print Calculator</h1>
-  <p class="text-muted">Dial in your sheet specs, finishing steps, and print-ready outputs from one bitchin’ workspace.</p>
+  <div class="layout-cluster" data-align="between">
+    <div class="layout-stack" data-gap="snug">
+      <h1>Kevin’s Bitchin’ Print Calculator</h1>
+      <p class="text-muted">
+        Dial in your sheet specs, finishing steps, and print-ready outputs from one bitchin’ workspace.
+      </p>
+    </div>
+    <button
+      type="button"
+      class="btn btn-ghost units-toggle"
+      data-role="units-toggle"
+      aria-pressed="true"
+      title="Switch to metric units"
+    >
+      <span data-role="units-toggle-label">Imperial Units</span>
+      <span data-role="units-toggle-abbr" aria-hidden="true">in</span>
+    </button>
+  </div>
 </header>

--- a/docs/html-partials/templates/tab-inputs-template.html
+++ b/docs/html-partials/templates/tab-inputs-template.html
@@ -20,13 +20,6 @@
     </div>
 
     <div class="layout-stack layout-scroll" data-gap="relaxed">
-      <div class="form-toolbar layout-cluster layout-sticky print-hidden" data-gap="snug" data-align="start">
-        <span>Units:</span>
-        <select id="units" class="form-select">
-          <option value="in">inches</option>
-          <option value="mm">millimeters</option>
-        </select>
-      </div>
 
       <div class="form-grid--dual">
         <div class="layout-stack" data-gap="relaxed">

--- a/docs/js/controllers/layout-updater.js
+++ b/docs/js/controllers/layout-updater.js
@@ -5,7 +5,7 @@ import {
   createCalculationContext,
 } from '../calculations/layout-calculations.js';
 import { calculateProgramSequence } from '../utils/program-sequence.js';
-import { isAutoMarginModeEnabled } from '../tabs/inputs.js';
+import { getCurrentUnits, isAutoMarginModeEnabled } from '../tabs/inputs.js';
 import {
   $,
   fillTable,
@@ -36,7 +36,7 @@ function updateDocCountField(selector, count) {
 }
 
 function currentInputs() {
-  const units = $('#units').value;
+  const units = getCurrentUnits();
   const u = (v) => (units === 'mm' ? (Number(v) || 0) / MM_PER_INCH : Number(v) || 0);
   const autoMargins = isAutoMarginModeEnabled();
   const rawMargins = {

--- a/docs/js/tabs/presets.js
+++ b/docs/js/tabs/presets.js
@@ -2,6 +2,7 @@ import { layoutPresets } from '../data/layout-presets.js';
 import { $, $$ } from '../utils/dom.js';
 import { formatValueForUnits } from '../utils/units.js';
 import { hydrateTabPanel } from './registry.js';
+import { getCurrentUnits } from './inputs.js';
 
 const TAB_KEY = 'presets';
 const marginInputSelectors = ['#mTop', '#mRight', '#mBottom', '#mLeft'];
@@ -46,7 +47,7 @@ function applyLayoutPreset(presetKey) {
   storedContext.enableAutoMarginMode?.(true);
   clearMarginInputs();
 
-  const units = $('#units')?.value || 'in';
+  const units = getCurrentUnits();
   const sheet = preset.sheet || {};
   const document = preset.document || {};
   const gutter = preset.gutter || {};


### PR DESCRIPTION
## Summary
- replace the inputs tab units select with a header-level toggle button that defaults to imperial units
- centralize unit state usage across tabs and refresh preset handling for the new control
- add red, white, and blue confetti to the imperial celebration and style the new toggle

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d7dbebbe083249fc86c7f820661a3)