### PR TITLE
Revamp layout alignment controls

### DIFF
--- a/docs/css/controls.css
+++ b/docs/css/controls.css
@@ -232,6 +232,71 @@ input[type="number"].form-control { text-align: right; }
   color: #ffffff;
 }
 
+.margin-auto-toggle {
+  white-space: nowrap;
+  font-size: var(--font-sm);
+}
+
+.margin-align__grid { --grid-min: 220px; }
+
+.margin-align__options {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.margin-align__option {
+  font-size: var(--font-sm);
+  font-weight: 500;
+  justify-content: center;
+}
+
+.margin-align__option[data-active='true'] {
+  background: color-mix(in srgb, var(--color-accent) 18%, var(--color-surface-2));
+  border-color: var(--color-border-accent);
+  color: var(--color-text-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 35%, transparent);
+}
+
+.margin-align__option:disabled,
+.margin-align__option[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.margin-align__hint {
+  font-size: var(--font-xs);
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.margin-align__inputs-hint {
+  font-size: var(--font-xs);
+  margin: 0 0 var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.margin-edge {
+  transition: border-color var(--motion-fast) ease, box-shadow var(--motion-fast) ease,
+    color var(--motion-fast) ease;
+}
+
+.margin-edge[data-anchor-active='true'] {
+  border-color: var(--color-border-accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 35%, transparent);
+  color: var(--color-text-primary);
+}
+
+.margin-edge[data-anchor-active='true'] span {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.margin-edge[data-auto='true'] {
+  opacity: 0.7;
+}
+
 /* ---- Tabs ---- */
 .tabs-nav {
   border-bottom: 1px solid var(--color-border);

--- a/docs/html-partials/templates/tab-inputs-template.html
+++ b/docs/html-partials/templates/tab-inputs-template.html
@@ -115,12 +115,51 @@
 
         <div class="layout-stack" data-gap="relaxed">
           <section class="form-section">
-            <h2>Margins (inside printable)</h2>
+            <div class="layout-stack" data-gap="tight">
+              <div class="layout-cluster" data-align="between">
+                <div class="layout-stack" data-gap="tight">
+                  <h2>Layout alignment</h2>
+                  <p class="text-muted" id="marginAlignSummary">
+                    Auto alignment balances the printable layout inside the sheet. Switch to manual offsets to anchor the layout to specific edges.
+                  </p>
+                </div>
+                <button type="button" class="btn btn-ghost margin-auto-toggle" id="marginAutoToggle" aria-pressed="true">
+                  Auto alignment: On
+                </button>
+              </div>
+              <div class="layout-grid margin-align__grid" data-cols="2" data-gap="snug">
+                <div class="layout-stack" data-gap="tight">
+                  <h3>Horizontal anchor</h3>
+                  <p class="text-muted margin-align__hint" id="marginHorizontalHint">
+                    Keep the layout centered left-to-right.
+                  </p>
+                  <div class="margin-align__options" role="group" aria-label="Horizontal alignment">
+                    <button type="button" class="btn margin-align__option" data-align-horizontal="left" aria-pressed="false">Left edge</button>
+                    <button type="button" class="btn margin-align__option" data-align-horizontal="center" aria-pressed="true">Centered</button>
+                    <button type="button" class="btn margin-align__option" data-align-horizontal="right" aria-pressed="false">Right edge</button>
+                  </div>
+                </div>
+                <div class="layout-stack" data-gap="tight">
+                  <h3>Vertical anchor</h3>
+                  <p class="text-muted margin-align__hint" id="marginVerticalHint">
+                    Keep the layout centered top-to-bottom.
+                  </p>
+                  <div class="margin-align__options" role="group" aria-label="Vertical alignment">
+                    <button type="button" class="btn margin-align__option" data-align-vertical="top" aria-pressed="false">Top edge</button>
+                    <button type="button" class="btn margin-align__option" data-align-vertical="center" aria-pressed="true">Centered</button>
+                    <button type="button" class="btn margin-align__option" data-align-vertical="bottom" aria-pressed="false">Bottom edge</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p class="text-muted margin-align__inputs-hint" id="marginInputHint">
+              Update the highlighted offsets below to pin the layout where you need it.
+            </p>
             <div class="form-row" data-cols="4">
-              <label class="form-label"><span>Top</span><input id="mTop" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
-              <label class="form-label"><span>Right</span><input id="mRight" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
-              <label class="form-label"><span>Bottom</span><input id="mBottom" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
-              <label class="form-label"><span>Left</span><input id="mLeft" class="form-control" type="number" step="0.125" data-inch-step="0.125" placeholder="auto" /></label>
+              <label class="form-label margin-edge" data-margin-edge="top" data-margin-axis="vertical"><span>Distance from top edge</span><input id="mTop" class="form-control" type="number" step="0.125" data-inch-step="0.125" /></label>
+              <label class="form-label margin-edge" data-margin-edge="right" data-margin-axis="horizontal"><span>Distance from right edge</span><input id="mRight" class="form-control" type="number" step="0.125" data-inch-step="0.125" /></label>
+              <label class="form-label margin-edge" data-margin-edge="bottom" data-margin-axis="vertical"><span>Distance from bottom edge</span><input id="mBottom" class="form-control" type="number" step="0.125" data-inch-step="0.125" /></label>
+              <label class="form-label margin-edge" data-margin-edge="left" data-margin-axis="horizontal"><span>Distance from left edge</span><input id="mLeft" class="form-control" type="number" step="0.125" data-inch-step="0.125" /></label>
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- replace the margin fields with a layout alignment panel that introduces anchor buttons, clearer copy, and an explicit auto toggle
- style the new alignment controls and margin fields so the active anchors and auto/manual states are visually obvious
- extend the inputs tab controller to drive the new UI, update alignment messaging, and synchronize the auto/manual behaviour

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8802205083249075c22595038ce3)