### PR TITLE
Auto-detect preferred measurement units

### DIFF
--- a/docs/js/tabs/inputs.js
+++ b/docs/js/tabs/inputs.js
@@ -8,6 +8,7 @@ import {
   getUnitsPrecision,
 } from '../utils/units.js';
 import { hydrateTabPanel } from './registry.js';
+import { detectPreferredUnits } from '../utils/measurement-system.js';
 
 const TAB_KEY = 'inputs';
 const marginInputSelectors = ['#mTop', '#mRight', '#mBottom', '#mLeft'];
@@ -34,6 +35,8 @@ const CANONICAL_INCHES_ATTR = 'inches';
  * layer always has a deterministic fallback.
  */
 const normalizeUnits = (units) => (units === 'mm' ? 'mm' : 'in');
+
+const INITIAL_UNITS = detectPreferredUnits(DEFAULT_INPUTS.units);
 
 /**
  * Persists the canonical inch measurement for a numeric input so the layout
@@ -146,7 +149,7 @@ const presetSelectionMemory = {
 
 let initialized = false;
 let autoMarginMode = true;
-let currentUnitsSelection = DEFAULT_INPUTS.units;
+let currentUnitsSelection = INITIAL_UNITS;
 let storedContext = { update: () => {}, status: () => {} };
 let keydownHandlerAttached = false;
 
@@ -574,7 +577,8 @@ function handleUnitCelebration(units) {
 }
 
 function applyDefaultInputs() {
-  const { units, sheet, document, gutter, nonPrintable } = DEFAULT_INPUTS;
+  const { sheet, document, gutter, nonPrintable } = DEFAULT_INPUTS;
+  const units = INITIAL_UNITS;
   setUnits(units, { skipConversion: true, silent: true });
   setAutoMarginMode(true);
 

--- a/docs/js/utils/measurement-system.js
+++ b/docs/js/utils/measurement-system.js
@@ -1,0 +1,57 @@
+const IMPERIAL_REGION_CODES = new Set(['US', 'LR', 'MM']);
+
+function extractRegion(locale) {
+  if (typeof locale !== 'string' || locale.length === 0) return null;
+  const parts = locale.split(/[-_]/);
+  for (let i = parts.length - 1; i >= 1; i -= 1) {
+    const part = parts[i];
+    if (typeof part !== 'string') continue;
+    if (/^[A-Za-z]{2}$/.test(part)) {
+      return part.toUpperCase();
+    }
+  }
+  return null;
+}
+
+function collectCandidateLocales() {
+  const locales = [];
+  if (typeof navigator !== 'undefined') {
+    if (Array.isArray(navigator.languages)) {
+      navigator.languages.forEach((loc) => {
+        if (typeof loc === 'string' && loc) {
+          locales.push(loc);
+        }
+      });
+    }
+    if (typeof navigator.language === 'string' && navigator.language) {
+      locales.push(navigator.language);
+    }
+  }
+  try {
+    const intlLocale = Intl?.DateTimeFormat?.().resolvedOptions()?.locale;
+    if (typeof intlLocale === 'string' && intlLocale) {
+      locales.push(intlLocale);
+    }
+  } catch (error) {
+    // Ignore Intl errors and fall back to the provided default.
+  }
+  return locales;
+}
+
+function normalizeUnits(units) {
+  return units === 'mm' ? 'mm' : 'in';
+}
+
+export function detectPreferredUnits(fallbackUnits = 'in') {
+  const fallback = normalizeUnits(fallbackUnits);
+  const locales = collectCandidateLocales();
+  for (const locale of locales) {
+    const region = extractRegion(locale);
+    if (!region) continue;
+    if (IMPERIAL_REGION_CODES.has(region)) {
+      return 'in';
+    }
+    return 'mm';
+  }
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- add a measurement-system utility that infers imperial vs metric units from the user locale without prompting for permissions
- initialize and reset the inputs tab with the detected units so the calculator defaults to the appropriate measurement system

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8e1e9e8c8324a393ee6ae4f407c9)