### PR TITLE
Adjust metric defaults and emphasize metric alert

### DIFF
--- a/docs/css/celebration.css
+++ b/docs/css/celebration.css
@@ -39,21 +39,38 @@
 
 .freedom-alert {
   position: fixed;
-  top: 20px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -55%) scale(0.98);
   z-index: 9999;
-  padding: 12px 20px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-surface-0) 88%, transparent);
+  padding: clamp(18px, 3vw, 32px) clamp(28px, 4vw, 44px);
+  border-radius: clamp(24px, 5vw, 48px);
+  background: color-mix(in srgb, var(--color-surface-0) 92%, transparent);
   color: var(--color-text-primary);
-  font-weight: 700;
+  display: grid;
+  gap: clamp(6px, 1.6vw, 14px);
+  justify-items: center;
+  text-align: center;
+  border: 3px solid color-mix(in srgb, var(--color-text-muted) 30%, transparent);
+  box-shadow: 0 20px 45px color-mix(in srgb, var(--color-text-inverse) 45%, transparent);
+  pointer-events: none;
+  max-inline-size: min(90vw, 560px);
+  animation: freedom-alert-fade 5s ease-in-out forwards;
+}
+
+.freedom-alert__headline {
+  font-size: clamp(1.6rem, 3.5vw + 1rem, 3rem);
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.freedom-alert__detail {
+  font-size: clamp(1.05rem, 1.6vw + 0.8rem, 1.75rem);
+  font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  border: 2px solid color-mix(in srgb, var(--color-text-muted) 40%, transparent);
-  box-shadow: 0 14px 30px color-mix(in srgb, var(--color-text-inverse) 35%, transparent);
-  pointer-events: none;
-  animation: freedom-alert-fade 3.5s ease-in-out forwards;
+  color: color-mix(in srgb, var(--color-text-primary) 80%, var(--color-text-muted) 20%);
 }
 
 .freedom-confetti {
@@ -105,18 +122,18 @@
 @keyframes freedom-alert-fade {
   0% {
     opacity: 0;
-    transform: translate(-50%, -6px);
+    transform: translate(-50%, -65%) scale(0.92);
   }
-  15% {
+  18% {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translate(-50%, -55%) scale(1);
   }
-  80% {
+  85% {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translate(-50%, -55%) scale(1);
   }
   100% {
     opacity: 0;
-    transform: translate(-50%, -6px);
+    transform: translate(-50%, -45%) scale(0.96);
   }
 }

--- a/docs/js/config/defaults.js
+++ b/docs/js/config/defaults.js
@@ -1,21 +1,63 @@
-export const DEFAULT_INPUTS = {
-  units: 'in',
-  sheet: {
-    width: 12,
-    height: 18,
+const SYSTEM_DEFAULT_INPUTS = {
+  imperial: {
+    sheet: {
+      width: 12,
+      height: 18,
+    },
+    document: {
+      width: 3.5,
+      height: 2,
+    },
+    gutter: {
+      horizontal: 0.125,
+      vertical: 0.125,
+    },
+    nonPrintable: {
+      top: 0.0625,
+      right: 0.0625,
+      bottom: 0.0625,
+      left: 0.0625,
+    },
   },
-  document: {
-    width: 3.5,
-    height: 2,
-  },
-  gutter: {
-    horizontal: 0.125,
-    vertical: 0.125,
-  },
-  nonPrintable: {
-    top: 0.0625,
-    right: 0.0625,
-    bottom: 0.0625,
-    left: 0.0625,
+  metric: {
+    sheet: {
+      width: 11.69291, // 297 mm
+      height: 16.53543, // 420 mm
+    },
+    document: {
+      width: 3.34646, // 85 mm
+      height: 2.16535, // 55 mm
+    },
+    gutter: {
+      horizontal: 0.11811, // 3 mm
+      vertical: 0.11811, // 3 mm
+    },
+    nonPrintable: {
+      top: 0.11811, // 3 mm
+      right: 0.11811, // 3 mm
+      bottom: 0.11811, // 3 mm
+      left: 0.11811, // 3 mm
+    },
   },
 };
+
+function cloneSystemDefaults(units, defaults) {
+  return {
+    units,
+    sheet: { ...defaults.sheet },
+    document: { ...defaults.document },
+    gutter: { ...defaults.gutter },
+    nonPrintable: { ...defaults.nonPrintable },
+  };
+}
+
+export function getDefaultInputsForUnits(units = 'in') {
+  const system = units === 'mm' ? 'metric' : 'imperial';
+  const normalizedUnits = system === 'metric' ? 'mm' : 'in';
+  const defaults = SYSTEM_DEFAULT_INPUTS[system];
+  return cloneSystemDefaults(normalizedUnits, defaults);
+}
+
+export const DEFAULT_INPUTS = getDefaultInputsForUnits('in');
+
+export { SYSTEM_DEFAULT_INPUTS };

--- a/docs/js/data/input-presets.js
+++ b/docs/js/data/input-presets.js
@@ -94,6 +94,13 @@ export const documentPresets = [
     systems: ['imperial'],
   },
   {
+    id: 'doc-85x55',
+    label: '85×55 mm (Business Card)',
+    width: 3.34646,
+    height: 2.16535,
+    systems: ['metric'],
+  },
+  {
     id: 'doc-a5',
     label: 'A5 (148×210 mm)',
     width: 5.82677,


### PR DESCRIPTION
## Summary
- add system-specific default inputs so metric mode defaults to A3 sheets, 85×55 mm cards, and 3 mm gutters
- remember default preset selections and reset values whenever the measurement system changes
- restyle and extend the "Freedom mode off" alert so the metric switch is prominent

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d90a2185c8324b99d881e4825d47e)