### PR TITLE
Fix metric document counts by tolerating floating rounding

### DIFF
--- a/tests/calculate-document-count.test.js
+++ b/tests/calculate-document-count.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { calculateDocumentCount } from '../docs/js/calculations/layout-calculations.js';
+
+describe('calculateDocumentCount', () => {
+  it('treats tiny floating point underflows as full capacity', () => {
+    const avail = 10.2755999999999989569;
+    const span = 3.34645999999999999019;
+    const gutter = 0.118110000000000006648;
+
+    expect(calculateDocumentCount(avail, span, gutter)).toBe(3);
+  });
+
+  it('does not round up when the ratio is genuinely below the next integer', () => {
+    const span = 3.34646;
+    const gutter = 0.11811;
+    const avail = 10.1023715; // Equivalent to ~2.95 documents of usable space.
+
+    expect(calculateDocumentCount(avail, span, gutter)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- adjust the layout document count calculation to absorb floating point underflow that previously dropped a column in metric mode
- add regression coverage for the tolerant rounding logic to ensure we neither over- nor under-count documents

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d9298cf6083248da05ad5031e91c7)