### PR TITLE
Add rounded corner controls and unify SVG renderers

### DIFF
--- a/docs/css/tabs/rounded-corners.css
+++ b/docs/css/tabs/rounded-corners.css
@@ -1,0 +1,40 @@
+.rounded-card__body {
+  padding-top: var(--space-3);
+}
+
+.rounded-corner-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-3);
+}
+
+.rounded-corner-grid .form-label {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.rounded-corner-preset-grid {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.rounded-corner-preset-group h4 {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+}
+
+.rounded-corner-preset-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.rounded-corner-preset-buttons .btn {
+  flex: 1 0 110px;
+  min-width: 110px;
+}
+
+.rounded-summary-card .summary-table {
+  width: 100%;
+}

--- a/docs/html-partials/fragments/tab-nav.html
+++ b/docs/html-partials/fragments/tab-nav.html
@@ -17,6 +17,7 @@
   <button type="button" class="tabs-trigger" data-tab="scores">Scores</button>
   <button type="button" class="tabs-trigger" data-tab="perforations">Perforations</button>
   <button type="button" class="tabs-trigger" data-tab="drilling">Drilling</button>
+  <button type="button" class="tabs-trigger" data-tab="rounded-corners">Rounded Corners</button>
   <button type="button" class="tabs-trigger" data-tab="warnings">Warnings</button>
   <button type="button" class="tabs-trigger" data-tab="print">Print</button>
   <button type="button" class="tabs-trigger" data-tab="presets">Presets</button>

--- a/docs/html-partials/templates/tab-rounded-corners-template.html
+++ b/docs/html-partials/templates/tab-rounded-corners-template.html
@@ -1,0 +1,107 @@
+<!--
+  Rounded corner configuration tab.
+  - Hydrated via docs/js/tabs/rounded-corners.js
+  - Provides global presets, per-corner overrides, and summary table.
+-->
+<template id="tab-rounded-corners-template">
+  <div class="finishing-pane layout-stack" data-gap="spacious">
+    <div class="finishing-layout">
+      <div class="finishing-column">
+        <div class="layout-card finishing-card finishing-card--intro">
+          <div class="finishing-card__title layout-stack" data-gap="snug">
+            <h3>Rounded Corner Visualizer</h3>
+            <p class="text-muted">
+              Apply common radii or dial in custom values per document corner. These controls only affect the visualizer and
+              exported SVG.
+            </p>
+          </div>
+        </div>
+
+        <div class="layout-card finishing-card rounded-card">
+          <div class="finishing-card__header">
+            <div class="finishing-card__title layout-stack" data-gap="snug">
+              <h3>Global radius</h3>
+              <p class="text-muted">Change this value to update every corner at once.</p>
+            </div>
+          </div>
+          <div class="rounded-card__body layout-stack" data-gap="snug">
+            <label class="form-label finishing-field" for="roundedCornerGlobal">
+              <span>Radius (<span data-role="rounded-corner-units">in</span>)</span>
+              <input id="roundedCornerGlobal" class="form-control" type="number" min="0" step="0.01" value="0" />
+            </label>
+            <p class="finishing-hint">Use the preset buttons below or type any value supported by the current units.</p>
+            <div class="rounded-corner-preset-grid">
+              <div class="rounded-corner-preset-group">
+                <h4>Imperial presets</h4>
+                <div class="rounded-corner-preset-buttons" data-role="rounded-corner-presets">
+                  <button type="button" class="btn btn-ghost" data-radius-inches="0">Square</button>
+                  <button type="button" class="btn btn-ghost" data-radius-inches="0.125">1/8 in</button>
+                  <button type="button" class="btn btn-ghost" data-radius-inches="0.25">1/4 in</button>
+                  <button type="button" class="btn btn-ghost" data-radius-inches="0.375">3/8 in</button>
+                  <button type="button" class="btn btn-ghost" data-radius-inches="0.5">1/2 in</button>
+                </div>
+              </div>
+              <div class="rounded-corner-preset-group">
+                <h4>Metric presets</h4>
+                <div class="rounded-corner-preset-buttons" data-role="rounded-corner-presets">
+                  <button type="button" class="btn btn-ghost" data-radius-millimeters="0">Square</button>
+                  <button type="button" class="btn btn-ghost" data-radius-millimeters="2">2 mm</button>
+                  <button type="button" class="btn btn-ghost" data-radius-millimeters="3">3 mm</button>
+                  <button type="button" class="btn btn-ghost" data-radius-millimeters="4">4 mm</button>
+                  <button type="button" class="btn btn-ghost" data-radius-millimeters="6">6 mm</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="layout-card finishing-card">
+          <div class="finishing-card__title layout-stack" data-gap="snug">
+            <h3>Individual corners</h3>
+            <p class="text-muted">Fine-tune each corner or set any value to zero to keep it square.</p>
+          </div>
+          <div class="rounded-corner-grid">
+            <label class="form-label" data-corner="topLeft">
+              <span>Top left (<span data-role="rounded-corner-units">in</span>)</span>
+              <input class="form-control" type="number" min="0" step="0.01" data-corner-input="topLeft" value="0" />
+            </label>
+            <label class="form-label" data-corner="topRight">
+              <span>Top right (<span data-role="rounded-corner-units">in</span>)</span>
+              <input class="form-control" type="number" min="0" step="0.01" data-corner-input="topRight" value="0" />
+            </label>
+            <label class="form-label" data-corner="bottomRight">
+              <span>Bottom right (<span data-role="rounded-corner-units">in</span>)</span>
+              <input class="form-control" type="number" min="0" step="0.01" data-corner-input="bottomRight" value="0" />
+            </label>
+            <label class="form-label" data-corner="bottomLeft">
+              <span>Bottom left (<span data-role="rounded-corner-units">in</span>)</span>
+              <input class="form-control" type="number" min="0" step="0.01" data-corner-input="bottomLeft" value="0" />
+            </label>
+          </div>
+        </div>
+
+        <input id="roundedCornersData" type="hidden" value='{"topLeft":0,"topRight":0,"bottomRight":0,"bottomLeft":0}' />
+      </div>
+
+      <div class="finishing-column finishing-results">
+        <div class="layout-card rounded-summary-card">
+          <div class="layout-stack" data-gap="snug">
+            <h3>Corner summary</h3>
+            <p class="text-muted">Values are reported in both inches and millimeters for quick reference.</p>
+          </div>
+          <table class="summary-table" id="roundedCornersSummary">
+            <thead>
+              <tr>
+                <th>Corner</th>
+                <th>Inches</th>
+                <th>Millimeters</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
     <!-- Markup only. Visual styles live in tab bundles and style.css while behavior lives in app.js. -->
     <link rel="stylesheet" href="./css/tabs/finishing.css" />
     <link rel="stylesheet" href="./css/tabs/drilling.css" />
+    <link rel="stylesheet" href="./css/tabs/rounded-corners.css" />
     <link rel="stylesheet" href="./css/style.css" />
   </head>
   <body>
@@ -30,6 +31,7 @@
           <section id="tab-scores" data-tab-template="tab-scores-template"></section>
           <section id="tab-perforations" data-tab-template="tab-perforations-template"></section>
           <section id="tab-drilling" data-tab-template="tab-drilling-template"></section>
+          <section id="tab-rounded-corners" data-tab-template="tab-rounded-corners-template"></section>
           <section id="tab-warnings" data-tab-template="tab-warnings-template"></section>
           <section id="tab-print" data-tab-template="tab-print-template"></section>
         </div>

--- a/docs/js/controllers/layout-updater.js
+++ b/docs/js/controllers/layout-updater.js
@@ -103,6 +103,37 @@ function readHolePlan() {
   }
 }
 
+function readRoundedCorners() {
+  const defaultCorners = { topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 };
+  const el = $('#roundedCornersData');
+  if (!el) {
+    return defaultCorners;
+  }
+  const raw = el.value;
+  if (!raw) {
+    return defaultCorners;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return defaultCorners;
+    }
+    const coerce = (value) => {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) && numeric > 0 ? numeric : 0;
+    };
+    return {
+      topLeft: coerce(parsed.topLeft),
+      topRight: coerce(parsed.topRight),
+      bottomRight: coerce(parsed.bottomRight),
+      bottomLeft: coerce(parsed.bottomLeft),
+    };
+  } catch (error) {
+    console.error('Failed to parse rounded corner data', error);
+    return defaultCorners;
+  }
+}
+
 export function status(txt) {
   $('#status').textContent = txt;
 }
@@ -149,6 +180,7 @@ export function update() {
     perforationVertical: inp.perfV,
     holePlan: inp.drilling,
   });
+  layout.roundedCorners = readRoundedCorners();
   const programSequence = calculateProgramSequence(layout);
 
   updateDocCountField('#forceAcross', layout.counts.across);

--- a/docs/js/init/register-tabs.js
+++ b/docs/js/init/register-tabs.js
@@ -3,6 +3,7 @@ import inputsTab, { enableAutoMarginMode, isAutoMarginModeEnabled } from '../tab
 import finishingTab from '../tabs/finishing.js';
 import perforationsTab from '../tabs/perforations.js';
 import drillingTab from '../tabs/drilling.js';
+import roundedCornersTab from '../tabs/rounded-corners.js';
 import presetsTab from '../tabs/presets.js';
 import printTab from '../tabs/print.js';
 import programSequenceTab from '../tabs/program-sequence.js';
@@ -19,6 +20,7 @@ const TAB_REGISTRATIONS = ({ update, status }) => [
   { module: scoresTab, context: { update, status } },
   { module: perforationsTab, context: { update, status } },
   { module: drillingTab, context: { update, status } },
+  { module: roundedCornersTab, context: { update, status } },
   { module: warningsTab, context: {} },
   { module: printTab, context: {} },
   {

--- a/docs/js/rendering/rounded-rect-path.js
+++ b/docs/js/rendering/rounded-rect-path.js
@@ -1,0 +1,84 @@
+const CORNER_KEYS = ['topLeft', 'topRight', 'bottomRight', 'bottomLeft'];
+
+function toPositiveNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 0;
+}
+
+export function normalizeCornerRadii(source) {
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+  const normalized = CORNER_KEYS.reduce((acc, key) => {
+    acc[key] = toPositiveNumber(source[key]);
+    return acc;
+  }, {});
+  return CORNER_KEYS.some((key) => normalized[key] > 0) ? normalized : null;
+}
+
+export function clampCornerRadii(radii, width, height) {
+  if (!radii) return null;
+  const safeWidth = Math.max(0, Number(width) || 0);
+  const safeHeight = Math.max(0, Number(height) || 0);
+  if (safeWidth === 0 || safeHeight === 0) {
+    return null;
+  }
+  const maxRadius = Math.min(safeWidth, safeHeight) / 2;
+  if (maxRadius <= 0) return null;
+  const clampValue = (value) => Math.min(Math.max(value, 0), maxRadius);
+  const clamped = CORNER_KEYS.reduce((acc, key) => {
+    acc[key] = clampValue(radii[key] ?? 0);
+    return acc;
+  }, {});
+  return CORNER_KEYS.some((key) => clamped[key] > 0) ? clamped : null;
+}
+
+export function scaleCornerRadii(radii, scale) {
+  if (!radii) return null;
+  const factor = Number(scale) || 1;
+  if (factor <= 0) return null;
+  return CORNER_KEYS.reduce((acc, key) => {
+    acc[key] = (radii[key] ?? 0) * factor;
+    return acc;
+  }, {});
+}
+
+export function buildRoundedRectPath(x, y, width, height, radii) {
+  if (!radii) return '';
+  const left = x;
+  const top = y;
+  const right = x + width;
+  const bottom = y + height;
+  const tl = radii.topLeft ?? 0;
+  const tr = radii.topRight ?? 0;
+  const br = radii.bottomRight ?? 0;
+  const bl = radii.bottomLeft ?? 0;
+  const commands = [];
+  commands.push(`M ${left + tl} ${top}`);
+  commands.push(`H ${right - tr}`);
+  if (tr > 0) {
+    commands.push(`Q ${right} ${top} ${right} ${top + tr}`);
+  } else {
+    commands.push(`L ${right} ${top}`);
+  }
+  commands.push(`V ${bottom - br}`);
+  if (br > 0) {
+    commands.push(`Q ${right} ${bottom} ${right - br} ${bottom}`);
+  } else {
+    commands.push(`L ${right} ${bottom}`);
+  }
+  commands.push(`H ${left + bl}`);
+  if (bl > 0) {
+    commands.push(`Q ${left} ${bottom} ${left} ${bottom - bl}`);
+  } else {
+    commands.push(`L ${left} ${bottom}`);
+  }
+  commands.push(`V ${top + tl}`);
+  if (tl > 0) {
+    commands.push(`Q ${left} ${top} ${left + tl} ${top}`);
+  } else {
+    commands.push(`L ${left} ${top}`);
+  }
+  commands.push('Z');
+  return commands.join(' ');
+}

--- a/docs/js/rendering/svg-layout-scene.js
+++ b/docs/js/rendering/svg-layout-scene.js
@@ -1,0 +1,286 @@
+import { createMeasurementId } from '../utils/dom.js';
+
+function getNonPrintableMetrics(sheet = {}) {
+  const region = sheet?.nonPrintable ?? {};
+  return {
+    top: Math.max(0, Number(region.top) || 0),
+    right: Math.max(0, Number(region.right) || 0),
+    bottom: Math.max(0, Number(region.bottom) || 0),
+    left: Math.max(0, Number(region.left) || 0),
+  };
+}
+
+function getPrintableDimensions(sheet, nonPrintable) {
+  const width = Math.max(0, sheet.rawWidth - nonPrintable.left - nonPrintable.right);
+  const height = Math.max(0, sheet.rawHeight - nonPrintable.top - nonPrintable.bottom);
+  return { width, height };
+}
+
+function toCornerValue(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 0;
+}
+
+function resolveRoundedCorners(source) {
+  const base = {
+    topLeft: 0,
+    topRight: 0,
+    bottomRight: 0,
+    bottomLeft: 0,
+  };
+  if (!source || typeof source !== 'object') return base;
+  return {
+    topLeft: toCornerValue(source.topLeft),
+    topRight: toCornerValue(source.topRight),
+    bottomRight: toCornerValue(source.bottomRight),
+    bottomLeft: toCornerValue(source.bottomLeft),
+  };
+}
+
+const hasRoundedCorners = (corners) => Object.values(corners).some((value) => value > 0);
+
+function addRect(items, rect) {
+  if (!rect) return;
+  items.push({ type: 'rect', ...rect });
+}
+
+function addLine(items, line) {
+  if (!line) return;
+  items.push({ type: 'line', ...line });
+}
+
+function addCircle(items, circle) {
+  if (!circle) return;
+  items.push({ type: 'circle', ...circle });
+}
+
+export function buildLayoutScene(layout, finishing = {}) {
+  if (!layout?.sheet) return null;
+  const width = Number(layout.sheet.rawWidth ?? 0);
+  const height = Number(layout.sheet.rawHeight ?? 0);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  const items = [];
+
+  addRect(items, {
+    x: 0,
+    y: 0,
+    width,
+    height,
+    layer: 'sheet',
+    classNames: ['svg-sheet-outline'],
+  });
+
+  const nonPrintable = getNonPrintableMetrics(layout.sheet);
+  const printable = getPrintableDimensions(layout.sheet, nonPrintable);
+
+  if (nonPrintable.top > 0) {
+    addRect(items, {
+      x: 0,
+      y: 0,
+      width,
+      height: nonPrintable.top,
+      layer: 'nonPrintable',
+      classNames: ['svg-nonprintable-region'],
+    });
+  }
+
+  if (nonPrintable.bottom > 0) {
+    addRect(items, {
+      x: 0,
+      y: height - nonPrintable.bottom,
+      width,
+      height: nonPrintable.bottom,
+      layer: 'nonPrintable',
+      classNames: ['svg-nonprintable-region'],
+    });
+  }
+
+  const verticalBandHeight = Math.max(0, height - nonPrintable.top - nonPrintable.bottom);
+  if (nonPrintable.left > 0 && verticalBandHeight > 0) {
+    addRect(items, {
+      x: 0,
+      y: nonPrintable.top,
+      width: nonPrintable.left,
+      height: verticalBandHeight,
+      layer: 'nonPrintable',
+      classNames: ['svg-nonprintable-region'],
+    });
+  }
+
+  if (nonPrintable.right > 0 && verticalBandHeight > 0) {
+    addRect(items, {
+      x: width - nonPrintable.right,
+      y: nonPrintable.top,
+      width: nonPrintable.right,
+      height: verticalBandHeight,
+      layer: 'nonPrintable',
+      classNames: ['svg-nonprintable-region'],
+    });
+  }
+
+  if (printable.width > 0 && printable.height > 0) {
+    addRect(items, {
+      x: nonPrintable.left,
+      y: nonPrintable.top,
+      width: printable.width,
+      height: printable.height,
+      layer: 'nonPrintable',
+      classNames: ['svg-printable-outline'],
+    });
+  }
+
+  addRect(items, {
+    x: layout.layoutArea.originX,
+    y: layout.layoutArea.originY,
+    width: layout.layoutArea.width,
+    height: layout.layoutArea.height,
+    layer: 'layout',
+    classNames: ['svg-layout-area'],
+  });
+
+  const docCorners = resolveRoundedCorners(layout.roundedCorners);
+  const shouldRoundDocs = hasRoundedCorners(docCorners);
+  const across = layout.counts?.across ?? 0;
+  const down = layout.counts?.down ?? 0;
+  for (let yIndex = 0; yIndex < down; yIndex += 1) {
+    for (let xIndex = 0; xIndex < across; xIndex += 1) {
+      const originX = layout.layoutArea.originX + xIndex * (layout.document.width + layout.gutter.horizontal);
+      const originY = layout.layoutArea.originY + yIndex * (layout.document.height + layout.gutter.vertical);
+      addRect(items, {
+        x: originX,
+        y: originY,
+        width: layout.document.width,
+        height: layout.document.height,
+        layer: 'docs',
+        classNames: ['svg-document-area'],
+        cornerRadii: shouldRoundDocs ? docCorners : null,
+      });
+    }
+  }
+
+  (finishing.cuts ?? []).forEach((cut, index) => {
+    const y = Number(cut?.inches ?? 0);
+    if (!Number.isFinite(y)) return;
+    addLine(items, {
+      x1: 0,
+      y1: y,
+      x2: width,
+      y2: y,
+      layer: 'cuts',
+      classNames: ['svg-cut-line'],
+      measurement: {
+        id: createMeasurementId('cut', index),
+        type: 'cut',
+      },
+    });
+  });
+
+  (finishing.slits ?? []).forEach((slit, index) => {
+    const x = Number(slit?.inches ?? 0);
+    if (!Number.isFinite(x)) return;
+    addLine(items, {
+      x1: x,
+      y1: 0,
+      x2: x,
+      y2: height,
+      layer: 'slits',
+      classNames: ['svg-slit-line'],
+      measurement: {
+        id: createMeasurementId('slit', index),
+        type: 'slit',
+      },
+    });
+  });
+
+  (finishing.scores?.horizontal ?? []).forEach((score, index) => {
+    const y = Number(score?.inches ?? 0);
+    if (!Number.isFinite(y)) return;
+    addLine(items, {
+      x1: layout.layoutArea.originX,
+      y1: y,
+      x2: layout.layoutArea.originX + layout.layoutArea.width,
+      y2: y,
+      layer: 'scores',
+      classNames: ['svg-score-line'],
+      measurement: {
+        id: createMeasurementId('score-horizontal', index),
+        type: 'score-horizontal',
+      },
+    });
+  });
+
+  (finishing.scores?.vertical ?? []).forEach((score, index) => {
+    const x = Number(score?.inches ?? 0);
+    if (!Number.isFinite(x)) return;
+    addLine(items, {
+      x1: x,
+      y1: layout.layoutArea.originY,
+      x2: x,
+      y2: layout.layoutArea.originY + layout.layoutArea.height,
+      layer: 'scores',
+      classNames: ['svg-score-line'],
+      measurement: {
+        id: createMeasurementId('score-vertical', index),
+        type: 'score-vertical',
+      },
+    });
+  });
+
+  (finishing.perforations?.horizontal ?? []).forEach((perforation, index) => {
+    const y = Number(perforation?.inches ?? 0);
+    if (!Number.isFinite(y)) return;
+    addLine(items, {
+      x1: layout.layoutArea.originX,
+      y1: y,
+      x2: layout.layoutArea.originX + layout.layoutArea.width,
+      y2: y,
+      layer: 'perforations',
+      classNames: ['svg-perforation-line'],
+      measurement: {
+        id: createMeasurementId('perforation-horizontal', index),
+        type: 'perforation-horizontal',
+      },
+    });
+  });
+
+  (finishing.perforations?.vertical ?? []).forEach((perforation, index) => {
+    const x = Number(perforation?.inches ?? 0);
+    if (!Number.isFinite(x)) return;
+    addLine(items, {
+      x1: x,
+      y1: layout.layoutArea.originY,
+      x2: x,
+      y2: layout.layoutArea.originY + layout.layoutArea.height,
+      layer: 'perforations',
+      classNames: ['svg-perforation-line'],
+      measurement: {
+        id: createMeasurementId('perforation-vertical', index),
+        type: 'perforation-vertical',
+      },
+    });
+  });
+
+  (finishing.holes ?? []).forEach((hole, index) => {
+    const diameter = Number(hole?.diameter ?? 0);
+    if (!Number.isFinite(diameter) || diameter <= 0) return;
+    const radius = diameter / 2;
+    const cx = Number(hole?.x ?? 0);
+    const cy = Number(hole?.y ?? 0);
+    addCircle(items, {
+      cx,
+      cy,
+      radius,
+      layer: 'holes',
+      classNames: ['svg-hole'],
+      measurement: {
+        id: createMeasurementId('hole', index),
+        type: 'hole',
+      },
+    });
+  });
+
+  return { width, height, items };
+}

--- a/docs/js/rendering/svg-preview-renderer.js
+++ b/docs/js/rendering/svg-preview-renderer.js
@@ -1,231 +1,55 @@
-import {
-  $,
-  applyLayerVisibility,
-  createMeasurementId,
-  restoreMeasurementSelections,
-} from '../utils/dom.js';
+import { $, applyLayerVisibility, restoreMeasurementSelections } from '../utils/dom.js';
+import { buildLayoutScene } from './svg-layout-scene.js';
 import { createCircleFactory, createLineFactory, createRectFactory } from './svg-shape-factories.js';
-
-function getNonPrintableMetrics(sheet) {
-  const nonPrintable = sheet?.nonPrintable ?? {};
-  return {
-    top: Math.max(0, nonPrintable.top ?? 0),
-    right: Math.max(0, nonPrintable.right ?? 0),
-    bottom: Math.max(0, nonPrintable.bottom ?? 0),
-    left: Math.max(0, nonPrintable.left ?? 0),
-  };
-}
-
-function getPrintableDimensions(sheet, nonPrintable) {
-  const width = Math.max(0, sheet.rawWidth - nonPrintable.left - nonPrintable.right);
-  const height = Math.max(0, sheet.rawHeight - nonPrintable.top - nonPrintable.bottom);
-
-  return { width, height };
-}
 
 export function drawSVG(layout, fin) {
   const svg = $('#svg');
+  if (!svg) return;
+  const scene = buildLayoutScene(layout, fin);
   const { width: viewBoxWidth, height: viewBoxHeight } = svg.viewBox.baseVal;
   const padding = 20;
 
   svg.innerHTML = '';
 
-  const scaleX = (viewBoxWidth - 2 * padding) / layout.sheet.rawWidth;
-  const scaleY = (viewBoxHeight - 2 * padding) / layout.sheet.rawHeight;
+  if (!scene) return;
+
+  const sheetWidth = scene.width;
+  const sheetHeight = scene.height;
+
+  const scaleX = (viewBoxWidth - 2 * padding) / sheetWidth;
+  const scaleY = (viewBoxHeight - 2 * padding) / sheetHeight;
   const scale = Math.min(scaleX, scaleY);
-  const offsetX = padding + (viewBoxWidth - 2 * padding - layout.sheet.rawWidth * scale) / 2;
-  const offsetY = padding + (viewBoxHeight - 2 * padding - layout.sheet.rawHeight * scale) / 2;
+  const offsetX = padding + (viewBoxWidth - 2 * padding - sheetWidth * scale) / 2;
+  const offsetY = padding + (viewBoxHeight - 2 * padding - sheetHeight * scale) / 2;
 
   const drawRect = createRectFactory(svg, scale, offsetX, offsetY);
   const drawLine = createLineFactory(svg, scale, offsetX, offsetY);
   const drawCircle = createCircleFactory(svg, scale, offsetX, offsetY);
-
-  drawRect(0, 0, layout.sheet.rawWidth, layout.sheet.rawHeight, {
-    layer: 'sheet',
-    classNames: ['svg-sheet-outline'],
-  });
-
-  const nonPrintable = getNonPrintableMetrics(layout.sheet);
-  const printable = getPrintableDimensions(layout.sheet, nonPrintable);
-
-  if (nonPrintable.top > 0) {
-    drawRect(0, 0, layout.sheet.rawWidth, nonPrintable.top, {
-      layer: 'nonPrintable',
-      classNames: ['svg-nonprintable-region'],
-    });
-  }
-
-  if (nonPrintable.bottom > 0) {
-    drawRect(0, layout.sheet.rawHeight - nonPrintable.bottom, layout.sheet.rawWidth, nonPrintable.bottom, {
-      layer: 'nonPrintable',
-      classNames: ['svg-nonprintable-region'],
-    });
-  }
-
-  const verticalBandHeight = Math.max(0, layout.sheet.rawHeight - nonPrintable.top - nonPrintable.bottom);
-  if (nonPrintable.left > 0 && verticalBandHeight > 0) {
-    drawRect(0, nonPrintable.top, nonPrintable.left, verticalBandHeight, {
-      layer: 'nonPrintable',
-      classNames: ['svg-nonprintable-region'],
-    });
-  }
-
-  if (nonPrintable.right > 0 && verticalBandHeight > 0) {
-    drawRect(
-      layout.sheet.rawWidth - nonPrintable.right,
-      nonPrintable.top,
-      nonPrintable.right,
-      verticalBandHeight,
-      {
-        layer: 'nonPrintable',
-        classNames: ['svg-nonprintable-region'],
-      },
-    );
-  }
-
-  if (printable.width > 0 && printable.height > 0) {
-    drawRect(nonPrintable.left, nonPrintable.top, printable.width, printable.height, {
-      layer: 'nonPrintable',
-      classNames: ['svg-printable-outline'],
-    });
-  }
-
-  drawRect(
-    layout.layoutArea.originX,
-    layout.layoutArea.originY,
-    layout.layoutArea.width,
-    layout.layoutArea.height,
-    {
-      layer: 'layout',
-      classNames: ['svg-layout-area'],
-    },
-  );
-
-  const across = layout.counts.across;
-  const down = layout.counts.down;
-
-  for (let y = 0; y < down; y++) {
-    for (let x = 0; x < across; x++) {
-      const documentOriginX =
-        layout.layoutArea.originX + x * (layout.document.width + layout.gutter.horizontal);
-      const documentOriginY =
-        layout.layoutArea.originY + y * (layout.document.height + layout.gutter.vertical);
-
-      drawRect(documentOriginX, documentOriginY, layout.document.width, layout.document.height, {
-        layer: 'docs',
-        classNames: ['svg-document-area'],
+  scene.items.forEach((item) => {
+    if (!item) return;
+    if (item.type === 'rect') {
+      drawRect(item.x, item.y, item.width, item.height, {
+        layer: item.layer,
+        classNames: item.classNames,
+        cornerRadii: item.cornerRadii,
+      });
+      return;
+    }
+    if (item.type === 'line') {
+      drawLine(item.x1, item.y1, item.x2, item.y2, {
+        layer: item.layer,
+        classNames: item.classNames,
+        measurement: item.measurement,
+      });
+      return;
+    }
+    if (item.type === 'circle') {
+      drawCircle(item.cx, item.cy, item.radius, {
+        layer: item.layer,
+        classNames: item.classNames,
+        measurement: item.measurement,
       });
     }
-  }
-
-  fin.cuts.forEach((cut, index) =>
-    drawLine(
-      layout.layoutArea.originX,
-      cut.inches,
-      layout.layoutArea.originX + layout.layoutArea.width,
-      cut.inches,
-      {
-        layer: 'cuts',
-        classNames: ['svg-cut-line'],
-        measurement: {
-          id: createMeasurementId('cut', index),
-          type: 'cut',
-        },
-      },
-    ),
-  );
-
-  fin.slits.forEach((slit, index) =>
-    drawLine(slit.inches, layout.layoutArea.originY, slit.inches, layout.layoutArea.originY + layout.layoutArea.height, {
-      layer: 'slits',
-      classNames: ['svg-slit-line'],
-      measurement: {
-        id: createMeasurementId('slit', index),
-        type: 'slit',
-      },
-    }),
-  );
-
-  fin.scores.horizontal.forEach((score, index) => {
-    drawLine(
-      layout.layoutArea.originX,
-      score.inches,
-      layout.layoutArea.originX + layout.layoutArea.width,
-      score.inches,
-      {
-        layer: 'scores',
-        classNames: ['svg-score-line'],
-        measurement: {
-          id: createMeasurementId('score-horizontal', index),
-          type: 'score-horizontal',
-        },
-      },
-    );
-  });
-
-  fin.scores.vertical.forEach((score, index) => {
-    drawLine(
-      score.inches,
-      layout.layoutArea.originY,
-      score.inches,
-      layout.layoutArea.originY + layout.layoutArea.height,
-      {
-        layer: 'scores',
-        classNames: ['svg-score-line'],
-        measurement: {
-          id: createMeasurementId('score-vertical', index),
-          type: 'score-vertical',
-        },
-      },
-    );
-  });
-
-  fin.perforations.horizontal.forEach((perforation, index) => {
-    drawLine(
-      layout.layoutArea.originX,
-      perforation.inches,
-      layout.layoutArea.originX + layout.layoutArea.width,
-      perforation.inches,
-      {
-        layer: 'perforations',
-        classNames: ['svg-perforation-line'],
-        measurement: {
-          id: createMeasurementId('perforation-horizontal', index),
-          type: 'perforation-horizontal',
-        },
-      },
-    );
-  });
-
-  fin.perforations.vertical.forEach((perforation, index) => {
-    drawLine(
-      perforation.inches,
-      layout.layoutArea.originY,
-      perforation.inches,
-      layout.layoutArea.originY + layout.layoutArea.height,
-      {
-        layer: 'perforations',
-        classNames: ['svg-perforation-line'],
-        measurement: {
-          id: createMeasurementId('perforation-vertical', index),
-          type: 'perforation-vertical',
-        },
-      },
-    );
-  });
-
-  (fin.holes ?? []).forEach((hole, index) => {
-    const diameter = Number(hole?.diameter ?? 0);
-    if (!Number.isFinite(diameter) || diameter <= 0) return;
-    const radius = diameter / 2;
-    drawCircle(hole.x ?? 0, hole.y ?? 0, radius, {
-      layer: 'holes',
-      classNames: ['svg-hole'],
-      measurement: {
-        id: createMeasurementId('hole', index),
-        type: 'hole',
-      },
-    });
   });
 
   applyLayerVisibility();

--- a/docs/js/rendering/svg-shape-factories.js
+++ b/docs/js/rendering/svg-shape-factories.js
@@ -1,5 +1,11 @@
 import { applyLayerAttributes } from './svg-layer-attributes.js';
 import { setupMeasurementLine } from './svg-measurement-lines.js';
+import {
+  buildRoundedRectPath,
+  clampCornerRadii,
+  normalizeCornerRadii,
+  scaleCornerRadii,
+} from './rounded-rect-path.js';
 
 function addClassNames(el, classNames = []) {
   if (!classNames) return;
@@ -15,13 +21,29 @@ function addClassNames(el, classNames = []) {
 }
 
 export function createRectFactory(svg, scale, offsetX, offsetY) {
-  return function drawRect(x, y, width, height, { layer, classNames } = {}) {
+  return function drawRect(x, y, width, height, { layer, classNames, cornerRadii } = {}) {
+    const normalized = normalizeCornerRadii(cornerRadii);
+    const rounded = clampCornerRadii(normalized, width, height);
+    const pxX = offsetX + x * scale;
+    const pxY = offsetY + y * scale;
+    const pxWidth = Math.max(0.5, width * scale);
+    const pxHeight = Math.max(0.5, height * scale);
+
+    if (rounded) {
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      const scaledRadii = scaleCornerRadii(rounded, scale);
+      path.setAttribute('d', buildRoundedRectPath(pxX, pxY, pxWidth, pxHeight, scaledRadii));
+      addClassNames(path, classNames);
+      applyLayerAttributes(path, layer);
+      svg.appendChild(path);
+      return;
+    }
+
     const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-    rect.setAttribute('x', offsetX + x * scale);
-    rect.setAttribute('y', offsetY + y * scale);
-    rect.setAttribute('width', Math.max(0.5, width * scale));
-    rect.setAttribute('height', Math.max(0.5, height * scale));
-    rect.setAttribute('rx', 6);
+    rect.setAttribute('x', pxX);
+    rect.setAttribute('y', pxY);
+    rect.setAttribute('width', pxWidth);
+    rect.setAttribute('height', pxHeight);
 
     addClassNames(rect, classNames);
     applyLayerAttributes(rect, layer);

--- a/docs/js/tabs/inputs.js
+++ b/docs/js/tabs/inputs.js
@@ -614,6 +614,19 @@ function convertInputs(fromUnits, toUnits) {
   applyNumericInputUnits(safeTo);
 }
 
+function broadcastUnitsChange(units) {
+  if (typeof document === 'undefined') return;
+  try {
+    document.dispatchEvent(
+      new CustomEvent('calculator:units-change', {
+        detail: { units },
+      }),
+    );
+  } catch (error) {
+    console.warn('Failed to broadcast units change', error);
+  }
+}
+
 function setUnits(nextUnits, options = {}) {
   if (!nextUnits) return;
   const { skipConversion = false, silent = false } = options;
@@ -631,6 +644,7 @@ function setUnits(nextUnits, options = {}) {
   updateUnitToggleDisplay(nextUnits);
   applyNumericInputUnits(nextUnits);
   refreshPresetDropdowns(nextSystem);
+  broadcastUnitsChange(nextUnits);
   if (!silent) {
     getStatus()('Units changed');
     getUpdate()();

--- a/docs/js/tabs/rounded-corners.js
+++ b/docs/js/tabs/rounded-corners.js
@@ -1,0 +1,247 @@
+import { hydrateTabPanel } from './registry.js';
+import { getCurrentUnits } from './inputs.js';
+import { MM_PER_INCH, formatInchesForUnits, inchesToMillimeters } from '../utils/units.js';
+
+const TAB_KEY = 'rounded-corners';
+const CORNER_KEYS = ['topLeft', 'topRight', 'bottomRight', 'bottomLeft'];
+const CORNER_LABELS = {
+  topLeft: 'Top left',
+  topRight: 'Top right',
+  bottomRight: 'Bottom right',
+  bottomLeft: 'Bottom left',
+};
+
+let initialized = false;
+let storedContext = { update: () => {}, status: () => {} };
+let panelEl = null;
+let unitListenerBound = false;
+
+const elements = {
+  globalInput: null,
+  cornerInputs: new Map(),
+  unitLabels: [],
+  presetButtons: [],
+  hiddenInput: null,
+  summaryBody: null,
+};
+
+let cornerValues = defaultCornerValues();
+let lastGlobalInches = 0;
+
+function defaultCornerValues() {
+  return { topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 };
+}
+
+const getUpdate = () => storedContext.update ?? (() => {});
+const getStatus = () => storedContext.status ?? (() => {});
+
+function ensurePanel() {
+  if (panelEl) return panelEl;
+  panelEl = hydrateTabPanel(TAB_KEY);
+  return panelEl;
+}
+
+function sanitizeInches(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+  return numeric;
+}
+
+function parseUnitsValue(value) {
+  if (value == null || value === '') return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return getCurrentUnits() === 'mm' ? numeric / MM_PER_INCH : numeric;
+}
+
+function readHiddenValues() {
+  const el = elements.hiddenInput;
+  if (!el || !el.value) return defaultCornerValues();
+  try {
+    const parsed = JSON.parse(el.value);
+    if (!parsed || typeof parsed !== 'object') {
+      return defaultCornerValues();
+    }
+    return {
+      topLeft: sanitizeInches(parsed.topLeft),
+      topRight: sanitizeInches(parsed.topRight),
+      bottomRight: sanitizeInches(parsed.bottomRight),
+      bottomLeft: sanitizeInches(parsed.bottomLeft),
+    };
+  } catch (error) {
+    console.warn('Unable to parse rounded corner cache', error);
+    return defaultCornerValues();
+  }
+}
+
+function syncHiddenValues() {
+  if (!elements.hiddenInput) return;
+  try {
+    elements.hiddenInput.value = JSON.stringify(cornerValues);
+  } catch (error) {
+    console.warn('Failed to serialize rounded corners', error);
+  }
+}
+
+function updateUnitLabels(units) {
+  elements.unitLabels.forEach((label) => {
+    label.textContent = units;
+  });
+}
+
+function setInputAttributes(input, units) {
+  if (!input) return;
+  input.setAttribute('step', units === 'mm' ? '0.5' : '0.01');
+}
+
+function renderGlobalInput(units) {
+  if (!elements.globalInput) return;
+  elements.globalInput.value = formatInchesForUnits(lastGlobalInches, units);
+  setInputAttributes(elements.globalInput, units);
+}
+
+function renderCornerInputs(units) {
+  elements.cornerInputs.forEach((input, corner) => {
+    const inches = cornerValues[corner] ?? 0;
+    input.value = formatInchesForUnits(inches, units);
+    setInputAttributes(input, units);
+  });
+}
+
+function renderSummary() {
+  if (!elements.summaryBody) return;
+  const rows = CORNER_KEYS.map((corner) => {
+    const inches = cornerValues[corner] ?? 0;
+    const rounded = inches > 0;
+    const label = CORNER_LABELS[corner];
+    const inchesText = inches.toFixed(3);
+    const mmText = inchesToMillimeters(inches, 2).toFixed(2);
+    const status = rounded ? 'Rounded' : 'Square';
+    return `<tr><td>${label}</td><td class="k">${inchesText}</td><td class="k">${mmText}</td><td>${status}</td></tr>`;
+  }).join('');
+  elements.summaryBody.innerHTML = rows;
+}
+
+function notifyChange(message) {
+  syncHiddenValues();
+  renderSummary();
+  getUpdate()();
+  if (message) {
+    getStatus()(message);
+  }
+}
+
+function applyGlobalRadius(inches, { message } = {}) {
+  lastGlobalInches = sanitizeInches(inches);
+  CORNER_KEYS.forEach((corner) => {
+    cornerValues[corner] = lastGlobalInches;
+  });
+  const units = getCurrentUnits();
+  renderGlobalInput(units);
+  renderCornerInputs(units);
+  notifyChange(message ?? 'Rounded corners updated');
+}
+
+function handleCornerInputChange(corner, value) {
+  const inches = parseUnitsValue(value);
+  if (inches == null) return;
+  cornerValues[corner] = sanitizeInches(inches);
+  notifyChange();
+}
+
+function handleGlobalInputChange(value) {
+  const inches = parseUnitsValue(value);
+  if (inches == null) return;
+  applyGlobalRadius(inches, { message: 'Applied rounded corner radius to all corners' });
+}
+
+function handlePresetClick(button) {
+  if (!button) return;
+  const inchesAttr = button.dataset.radiusInches;
+  const mmAttr = button.dataset.radiusMillimeters;
+  let inches = null;
+  if (inchesAttr != null) {
+    inches = Number(inchesAttr);
+  } else if (mmAttr != null) {
+    const millimeters = Number(mmAttr);
+    if (Number.isFinite(millimeters)) {
+      inches = millimeters / MM_PER_INCH;
+    }
+  }
+  if (inches == null || !Number.isFinite(inches) || inches < 0) return;
+  applyGlobalRadius(inches, { message: 'Rounded corner preset applied' });
+}
+
+function handleUnitsChange(event) {
+  const units = event?.detail?.units ?? getCurrentUnits();
+  updateUnitLabels(units);
+  renderGlobalInput(units);
+  renderCornerInputs(units);
+}
+
+function bindEvents() {
+  if (elements.globalInput) {
+    elements.globalInput.addEventListener('input', (evt) => handleGlobalInputChange(evt.target.value));
+  }
+  elements.cornerInputs.forEach((input, corner) => {
+    input.addEventListener('input', (evt) => handleCornerInputChange(corner, evt.target.value));
+  });
+  elements.presetButtons.forEach((button) => {
+    button.addEventListener('click', () => handlePresetClick(button));
+  });
+  if (!unitListenerBound && typeof document !== 'undefined') {
+    document.addEventListener('calculator:units-change', handleUnitsChange);
+    unitListenerBound = true;
+  }
+}
+
+function cacheElements() {
+  const panel = ensurePanel();
+  if (!panel) return;
+  elements.globalInput = panel.querySelector('#roundedCornerGlobal');
+  elements.unitLabels = Array.from(panel.querySelectorAll('[data-role="rounded-corner-units"]'));
+  elements.summaryBody = panel.querySelector('#roundedCornersSummary tbody');
+  elements.hiddenInput = panel.querySelector('#roundedCornersData');
+  elements.cornerInputs.clear();
+  CORNER_KEYS.forEach((corner) => {
+    const input = panel.querySelector(`[data-corner-input="${corner}"]`);
+    if (input) {
+      elements.cornerInputs.set(corner, input);
+    }
+  });
+  elements.presetButtons = Array.from(panel.querySelectorAll('[data-role="rounded-corner-presets"] button'));
+}
+
+function renderInitialState() {
+  cornerValues = readHiddenValues();
+  lastGlobalInches = cornerValues.topLeft ?? 0;
+  const units = getCurrentUnits();
+  updateUnitLabels(units);
+  renderGlobalInput(units);
+  renderCornerInputs(units);
+  renderSummary();
+}
+
+function init(context = {}) {
+  storedContext = { ...storedContext, ...context };
+  ensurePanel();
+  if (initialized || !panelEl) return;
+  cacheElements();
+  renderInitialState();
+  bindEvents();
+  syncHiddenValues();
+  initialized = true;
+}
+
+const roundedCornersTab = {
+  key: TAB_KEY,
+  init,
+  onActivate() {
+    init(storedContext);
+  },
+  onRegister(context) {
+    init(context);
+  },
+};
+
+export default roundedCornersTab;


### PR DESCRIPTION
## Summary
- add a rounded corners planning tab with presets, per-corner inputs, and summary output next to the drilling tab
- unify the preview and print SVG renderers with a shared layout scene builder, extend cuts/slits across the sheet, and support rounded document corners
- broadcast unit changes and wire the new rounded-corner state through the layout updater so both visualizers and exports stay in sync

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4c5246348324a65182398a4774d7)