### PR TITLE
Revamp summary calculators layout

### DIFF
--- a/docs/css/layout.css
+++ b/docs/css/layout.css
@@ -177,6 +177,137 @@ th { color: var(--color-text-secondary); font-weight: 500; letter-spacing: 0.02e
 /* ---- Summary layout ---- */
 .summary-shell { flex: 1; min-height: 0; }
 
+.summary-calculators { gap: var(--space-5); }
+
+.summary-calculators__intro > * { margin: 0; }
+
+.summary-calculators__eyebrow {
+  margin: 0;
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.summary-calculators__shell {
+  display: flex;
+  gap: var(--space-4);
+  align-items: stretch;
+}
+
+.summary-calculators__tablist {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-2);
+  min-width: 240px;
+}
+
+.summary-calculator-tab {
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  font-size: var(--font-md);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color var(--motion-fast), background var(--motion-fast), color var(--motion-fast);
+}
+
+.summary-calculator-tab__title {
+  display: block;
+  font-size: var(--font-md);
+}
+
+.summary-calculator-tab__hint {
+  display: block;
+  margin-top: 2px;
+  font-size: var(--font-sm);
+  color: var(--color-text-muted);
+}
+
+.summary-calculator-tab[aria-selected='true'] {
+  color: var(--color-text-primary);
+  background: var(--color-surface-1);
+  border-color: var(--color-border);
+  box-shadow: inset 0 0 0 1px var(--color-border-muted);
+}
+
+.summary-calculator-tab:focus-visible,
+.summary-calculator__quick-pick:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.summary-calculators__panels {
+  flex: 1;
+  min-width: 0;
+}
+
+.summary-calculator__panel {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.summary-calculator__panel-header > * {
+  margin: 0;
+}
+
+.summary-calculator__eyebrow {
+  font-size: var(--font-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+.summary-calculator__grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  align-items: start;
+}
+
+.summary-calculator__quick-picks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-muted);
+  background: var(--color-surface-2);
+}
+
+.summary-calculator__quick-label {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-right: var(--space-1);
+}
+
+.summary-calculator__quick-pick {
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-sm);
+  padding: 4px 12px;
+  background: var(--color-surface-0);
+  color: var(--color-text-primary);
+  font-size: var(--font-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color var(--motion-fast), background var(--motion-fast);
+}
+
+.summary-calculator__quick-pick:hover {
+  border-color: var(--color-border);
+  background: var(--color-surface-1);
+}
+
 .summary-grid {
   display: grid;
   gap: var(--space-3);
@@ -198,6 +329,14 @@ th { color: var(--color-text-secondary); font-weight: 500; letter-spacing: 0.02e
   .layout-shell { padding-inline: var(--space-4); }
   .layout-grid[data-collapse="md"] { grid-template-columns: 1fr !important; }
   .layout-cluster[data-align="between"] { justify-content: flex-start; }
+  .summary-calculators__shell { flex-direction: column; }
+  .summary-calculators__tablist {
+    flex-direction: row;
+    min-width: 0;
+    overflow-x: auto;
+  }
+  .summary-calculator-tab { flex: 1; min-width: 200px; }
+  .summary-calculator__grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 720px) {

--- a/docs/html-partials/templates/tab-summary-template.html
+++ b/docs/html-partials/templates/tab-summary-template.html
@@ -2,173 +2,241 @@
   Load timing:
     - Cloned into #tab-summary by docs/js/tabs/registry.hydrateTabPanel('summary') after templates load during bootstrap.
   Key selectors:
-    - Metrics spans (#vAcross, #vDown, #vTotal, #vLayout, #vOrigin, #vRealMargins, #vUsed, #vTrail).
+    - Calculator tab buttons (.summary-calculator-tab) toggle panels (.summary-calculator__panel).
   JS dependencies:
-    - docs/js/tabs/summary.js writes calculated metrics into the spans on activation/registration.
-    - docs/js/app.js feeds formatted measurement strings used by the summary module for display updates.
+    - docs/js/tabs/summary.js wires controllers for calculators after hydration.
+    - docs/js/controllers/summary-calculators.js manages calculations, tab behavior, and quick actions.
 -->
 
 <template id="tab-summary-template">
-  <div class="summary-grid">
-    <article class="layout-card summary-card">
-      <h3>Counts</h3>
-      <dl class="summary-metrics">
-        <div>
-          <dt>Across</dt>
-          <dd class="text-metric" id="vAcross">—</dd>
-        </div>
-        <div>
-          <dt>Down</dt>
-          <dd class="text-metric" id="vDown">—</dd>
-        </div>
-        <div>
-          <dt>Total</dt>
-          <dd class="text-metric" id="vTotal">—</dd>
-        </div>
-      </dl>
-    </article>
-    <article class="layout-card summary-card">
-      <h3>Layout Area</h3>
-      <dl class="summary-metrics">
-        <div>
-          <dt>W × H</dt>
-          <dd class="text-metric" id="vLayout">—</dd>
-        </div>
-        <div>
-          <dt>Origin</dt>
-          <dd class="text-metric" id="vOrigin">—</dd>
-        </div>
-        <div>
-          <dt>Realized Margins</dt>
-          <dd class="text-metric" id="vRealMargins">—</dd>
-        </div>
-      </dl>
-    </article>
-    <article class="layout-card summary-card">
-      <h3>Utilization</h3>
-      <dl class="summary-metrics">
-        <div>
-          <dt>Used W/H</dt>
-          <dd class="text-metric" id="vUsed">—</dd>
-        </div>
-        <div>
-          <dt>Trailing W/H</dt>
-          <dd class="text-metric" id="vTrail">—</dd>
-        </div>
-      </dl>
-    </article>
-  </div>
+  <section class="layout-stack summary-calculators" data-gap="spacious" aria-label="Production calculators">
+    <header class="summary-calculators__intro layout-stack" data-gap="snug">
+      <p class="summary-calculators__eyebrow">Run planning</p>
+      <h2>Production helpers</h2>
+      <p class="text-muted">
+        Compare three focused calculators without leaving the layout screen. Pick the workflow that fits the job and
+        plug in your counts, spoilage, or pad sizes for instant guidance.
+      </p>
+    </header>
 
-  <section class="layout-stack" data-gap="relaxed" aria-label="Production calculators">
-    <div class="layout-grid" data-gap="relaxed" data-cols="auto" data-min="280">
-      <article class="layout-card layout-stack summary-calculator" data-gap="snug" data-calculator="pad">
-        <header class="layout-stack" data-gap="snug">
-          <h3>Pad Calculator</h3>
-          <p class="text-muted">Work out how many press sheets you need to build padded sets.</p>
-        </header>
-        <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
-          <label class="form-label summary-calculator__field">
-            <span>Number of pads</span>
-            <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="padCount" placeholder="0" />
-          </label>
-          <label class="form-label summary-calculator__field">
-            <span>Sheets per pad</span>
-            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="padSheets" value="50" />
-            <span class="text-muted summary-calculator__hint">Defaulted to 50 finished sheets per pad.</span>
-          </label>
-          <label class="form-label summary-calculator__field">
-            <span>N-up (per press sheet)</span>
-            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="padNUp" />
-            <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
-          </label>
-        </form>
-        <dl class="summary-calculator__results summary-metrics" aria-live="polite">
-          <div>
-            <dt>Finished pieces</dt>
-            <dd class="text-metric" id="padTotalPieces">—</dd>
-          </div>
-          <div>
-            <dt>Press sheets to print</dt>
-            <dd class="text-metric" id="padTotalSheets">—</dd>
-          </div>
-          <div>
-            <dt>Overage after padding</dt>
-            <dd class="text-metric" id="padRemainder">—</dd>
-          </div>
-        </dl>
-      </article>
+    <div class="summary-calculators__shell">
+      <div class="summary-calculators__tablist" role="tablist" aria-label="Choose a calculator">
+        <button
+          class="summary-calculator-tab"
+          type="button"
+          id="calc-tab-pad"
+          data-calculator-tab="pad"
+          data-default="true"
+          aria-controls="calc-panel-pad"
+          aria-selected="true"
+        >
+          <span class="summary-calculator-tab__title">Pad Calculator</span>
+          <span class="summary-calculator-tab__hint">Build padded sets</span>
+        </button>
+        <button
+          class="summary-calculator-tab"
+          type="button"
+          id="calc-tab-run"
+          data-calculator-tab="run"
+          aria-controls="calc-panel-run"
+          aria-selected="false"
+          tabindex="-1"
+        >
+          <span class="summary-calculator-tab__title">Target Quantity Planner</span>
+          <span class="summary-calculator-tab__hint">Start from a goal count</span>
+        </button>
+        <button
+          class="summary-calculator-tab"
+          type="button"
+          id="calc-tab-sheets"
+          data-calculator-tab="sheets"
+          aria-controls="calc-panel-sheets"
+          aria-selected="false"
+          tabindex="-1"
+        >
+          <span class="summary-calculator-tab__title">Sheets to Pads Converter</span>
+          <span class="summary-calculator-tab__hint">Translate a press run</span>
+        </button>
+      </div>
 
-      <article class="layout-card layout-stack summary-calculator" data-gap="snug" data-calculator="run">
-        <header class="layout-stack" data-gap="snug">
-          <h3>Target Quantity Planner</h3>
-          <p class="text-muted">Start from a desired finished quantity and include spoilage/overs.</p>
-        </header>
-        <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
-          <label class="form-label summary-calculator__field">
-            <span>Desired finished pieces</span>
-            <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="runDesired" placeholder="0" />
-          </label>
-          <label class="form-label summary-calculator__field">
-            <span>N-up (per press sheet)</span>
-            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="runNUp" />
-            <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
-          </label>
-          <label class="form-label summary-calculator__field">
-            <span>Spoilage / overs (%)</span>
-            <input class="form-control" type="number" inputmode="decimal" min="0" step="0.1" id="runOvers" value="0" />
-          </label>
-        </form>
-        <dl class="summary-calculator__results summary-metrics" aria-live="polite">
-          <div>
-            <dt>Finished pieces with overs</dt>
-            <dd class="text-metric" id="runTotalPieces">—</dd>
+      <div class="summary-calculators__panels">
+        <article
+          class="layout-card summary-calculator__panel"
+          data-calculator-panel="pad"
+          id="calc-panel-pad"
+          role="tabpanel"
+          aria-labelledby="calc-tab-pad"
+        >
+          <div class="summary-calculator__panel-header layout-stack" data-gap="snug">
+            <p class="summary-calculator__eyebrow">Pads & finishing</p>
+            <h3>Pad Calculator</h3>
+            <p class="text-muted">Work out how many press sheets you need to build padded sets.</p>
           </div>
-          <div>
-            <dt>Press sheets to print</dt>
-            <dd class="text-metric" id="runTotalSheets">—</dd>
-          </div>
-          <div>
-            <dt>Overs (pieces / sheets)</dt>
-            <dd class="text-metric" id="runOversBreakdown">—</dd>
-          </div>
-        </dl>
-      </article>
 
-      <article class="layout-card layout-stack summary-calculator" data-gap="snug" data-calculator="sheets">
-        <header class="layout-stack" data-gap="snug">
-          <h3>Sheets to Pads Converter</h3>
-          <p class="text-muted">Translate a press run into finished pieces and pad counts.</p>
-        </header>
-        <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
-          <label class="form-label summary-calculator__field">
-            <span>Press sheets to run</span>
-            <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="sheetRun" placeholder="0" />
-          </label>
-          <label class="form-label summary-calculator__field">
-            <span>N-up (per press sheet)</span>
-            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="sheetNUp" />
-            <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
-          </label>
-          <label class="form-label summary-calculator__field">
-            <span>Finished pieces per pad</span>
-            <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="sheetPerPad" value="50" />
-          </label>
-        </form>
-        <dl class="summary-calculator__results summary-metrics" aria-live="polite">
-          <div>
-            <dt>Total finished pieces</dt>
-            <dd class="text-metric" id="sheetTotalPieces">—</dd>
+          <div class="summary-calculator__quick-picks" role="group" aria-label="Common pad sizes">
+            <span class="summary-calculator__quick-label">Common pad sizes</span>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#padSheets" data-value="25">
+              25 sheets
+            </button>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#padSheets" data-value="50">
+              50 sheets
+            </button>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#padSheets" data-value="100">
+              100 sheets
+            </button>
           </div>
-          <div>
-            <dt>Complete pads</dt>
-            <dd class="text-metric" id="sheetTotalPads">—</dd>
+
+          <div class="summary-calculator__grid">
+            <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
+              <label class="form-label summary-calculator__field">
+                <span>Number of pads</span>
+                <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="padCount" placeholder="0" />
+              </label>
+              <label class="form-label summary-calculator__field">
+                <span>Sheets per pad</span>
+                <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="padSheets" value="50" />
+                <span class="text-muted summary-calculator__hint">Defaulted to 50 finished sheets per pad.</span>
+              </label>
+              <label class="form-label summary-calculator__field">
+                <span>N-up (per press sheet)</span>
+                <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="padNUp" />
+                <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
+              </label>
+            </form>
+
+            <dl class="summary-calculator__results summary-metrics" aria-live="polite">
+              <div>
+                <dt>Finished pieces</dt>
+                <dd class="text-metric" id="padTotalPieces">—</dd>
+              </div>
+              <div>
+                <dt>Press sheets to print</dt>
+                <dd class="text-metric" id="padTotalSheets">—</dd>
+              </div>
+              <div>
+                <dt>Overage after padding</dt>
+                <dd class="text-metric" id="padRemainder">—</dd>
+              </div>
+            </dl>
           </div>
-          <div>
-            <dt>Leftover pieces</dt>
-            <dd class="text-metric" id="sheetPadRemainder">—</dd>
+        </article>
+
+        <article
+          class="layout-card summary-calculator__panel"
+          data-calculator-panel="run"
+          id="calc-panel-run"
+          role="tabpanel"
+          aria-labelledby="calc-tab-run"
+          hidden
+        >
+          <div class="summary-calculator__panel-header layout-stack" data-gap="snug">
+            <p class="summary-calculator__eyebrow">Run targets</p>
+            <h3>Target Quantity Planner</h3>
+            <p class="text-muted">Start from a desired finished quantity and include spoilage/overs.</p>
           </div>
-        </dl>
-      </article>
+
+          <div class="summary-calculator__quick-picks" role="group" aria-label="Spoilage presets">
+            <span class="summary-calculator__quick-label">Spoilage presets</span>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#runOvers" data-value="0">0%</button>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#runOvers" data-value="5">5%</button>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#runOvers" data-value="10">10%</button>
+          </div>
+
+          <div class="summary-calculator__grid">
+            <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
+              <label class="form-label summary-calculator__field">
+                <span>Desired finished pieces</span>
+                <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="runDesired" placeholder="0" />
+              </label>
+              <label class="form-label summary-calculator__field">
+                <span>N-up (per press sheet)</span>
+                <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="runNUp" />
+                <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
+              </label>
+              <label class="form-label summary-calculator__field">
+                <span>Spoilage / overs (%)</span>
+                <input class="form-control" type="number" inputmode="decimal" min="0" step="0.1" id="runOvers" value="0" />
+              </label>
+            </form>
+
+            <dl class="summary-calculator__results summary-metrics" aria-live="polite">
+              <div>
+                <dt>Finished pieces with overs</dt>
+                <dd class="text-metric" id="runTotalPieces">—</dd>
+              </div>
+              <div>
+                <dt>Press sheets to print</dt>
+                <dd class="text-metric" id="runTotalSheets">—</dd>
+              </div>
+              <div>
+                <dt>Overs (pieces / sheets)</dt>
+                <dd class="text-metric" id="runOversBreakdown">—</dd>
+              </div>
+            </dl>
+          </div>
+        </article>
+
+        <article
+          class="layout-card summary-calculator__panel"
+          data-calculator-panel="sheets"
+          id="calc-panel-sheets"
+          role="tabpanel"
+          aria-labelledby="calc-tab-sheets"
+          hidden
+        >
+          <div class="summary-calculator__panel-header layout-stack" data-gap="snug">
+            <p class="summary-calculator__eyebrow">Reverse planning</p>
+            <h3>Sheets to Pads Converter</h3>
+            <p class="text-muted">Translate a press run into finished pieces and pad counts.</p>
+          </div>
+
+          <div class="summary-calculator__quick-picks" role="group" aria-label="Finished pieces per pad presets">
+            <span class="summary-calculator__quick-label">Pieces per pad</span>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#sheetPerPad" data-value="25">
+              25 pieces
+            </button>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#sheetPerPad" data-value="50">
+              50 pieces
+            </button>
+            <button class="summary-calculator__quick-pick" type="button" data-target="#sheetPerPad" data-value="100">
+              100 pieces
+            </button>
+          </div>
+
+          <div class="summary-calculator__grid">
+            <form class="summary-calculator__form layout-stack" data-gap="snug" autocomplete="off">
+              <label class="form-label summary-calculator__field">
+                <span>Press sheets to run</span>
+                <input class="form-control" type="number" inputmode="numeric" min="0" step="1" id="sheetRun" placeholder="0" />
+              </label>
+              <label class="form-label summary-calculator__field">
+                <span>N-up (per press sheet)</span>
+                <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="sheetNUp" />
+                <span class="text-muted summary-calculator__hint">Auto-fills from the current layout.</span>
+              </label>
+              <label class="form-label summary-calculator__field">
+                <span>Finished pieces per pad</span>
+                <input class="form-control" type="number" inputmode="numeric" min="1" step="1" id="sheetPerPad" value="50" />
+              </label>
+            </form>
+
+            <dl class="summary-calculator__results summary-metrics" aria-live="polite">
+              <div>
+                <dt>Total finished pieces</dt>
+                <dd class="text-metric" id="sheetTotalPieces">—</dd>
+              </div>
+              <div>
+                <dt>Complete pads</dt>
+                <dd class="text-metric" id="sheetTotalPads">—</dd>
+              </div>
+              <div>
+                <dt>Leftover pieces</dt>
+                <dd class="text-metric" id="sheetPadRemainder">—</dd>
+              </div>
+            </dl>
+          </div>
+        </article>
+      </div>
     </div>
   </section>
 </template>

--- a/docs/js/controllers/summary-calculators.js
+++ b/docs/js/controllers/summary-calculators.js
@@ -14,10 +14,14 @@ const INPUT_SELECTORS = [
   '#sheetNUp',
   '#sheetPerPad',
 ];
+const TAB_SELECTOR = '.summary-calculator-tab';
+const PANEL_SELECTOR = '.summary-calculator__panel';
+const QUICK_PICK_SELECTOR = '.summary-calculator__quick-pick';
 
 let isInitialized = false;
 let autoNUp = 1;
 let pendingAutoNUp = null;
+let activeCalculator = null;
 
 const formatNumber = (value) => {
   if (!Number.isFinite(value)) {
@@ -174,6 +178,74 @@ const recalcAll = () => {
   updateSheetsConverter();
 };
 
+const activateCalculator = (calculatorId) => {
+  if (!calculatorId) {
+    return;
+  }
+  activeCalculator = calculatorId;
+  $$(TAB_SELECTOR).forEach((tab) => {
+    const isActive = tab.dataset.calculatorTab === calculatorId;
+    tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    tab.tabIndex = isActive ? 0 : -1;
+  });
+  $$(PANEL_SELECTOR).forEach((panel) => {
+    const isActive = panel.dataset.calculatorPanel === calculatorId;
+    panel.hidden = !isActive;
+  });
+};
+
+const bindCalculatorTabs = () => {
+  const tabs = $$(TAB_SELECTOR);
+  if (!tabs.length) {
+    return;
+  }
+  const defaultTab = tabs.find((tab) => tab.dataset.default === 'true');
+  activateCalculator(defaultTab?.dataset.calculatorTab || tabs[0].dataset.calculatorTab);
+  tabs.forEach((tab, index) => {
+    tab.addEventListener('click', () => {
+      const calculatorId = tab.dataset.calculatorTab;
+      activateCalculator(calculatorId);
+      tab.focus();
+    });
+    tab.addEventListener('keydown', (event) => {
+      if (!['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+        return;
+      }
+      event.preventDefault();
+      const lastIndex = tabs.length - 1;
+      let nextIndex = index;
+      if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+        nextIndex = index === lastIndex ? 0 : index + 1;
+      } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+        nextIndex = index === 0 ? lastIndex : index - 1;
+      } else if (event.key === 'Home') {
+        nextIndex = 0;
+      } else if (event.key === 'End') {
+        nextIndex = lastIndex;
+      }
+      const nextTab = tabs[nextIndex];
+      if (nextTab) {
+        activateCalculator(nextTab.dataset.calculatorTab);
+        nextTab.focus();
+      }
+    });
+  });
+};
+
+const bindQuickPickButtons = () => {
+  $$(QUICK_PICK_SELECTOR).forEach((button) => {
+    button.addEventListener('click', () => {
+      const selector = button.dataset.target;
+      if (!selector) return;
+      const input = $(selector);
+      if (!input) return;
+      input.value = button.dataset.value ?? '';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+};
+
 function attachEventListeners() {
   INPUT_SELECTORS.forEach((selector) => {
     const input = $(selector);
@@ -226,6 +298,8 @@ export function initializeSummaryCalculators() {
     return;
   }
   isInitialized = true;
+  bindCalculatorTabs();
+  bindQuickPickButtons();
   attachEventListeners();
   ensureDefaultValues();
   syncAutoFillInputs();


### PR DESCRIPTION
## Summary
- replace the summary metrics grid with a tabbed experience for the pad, target quantity, and sheets converters, including preset buttons and improved hierarchy
- add the supporting styles and controller logic to drive the new tab interactions and quick-pick buttons

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4d004ce083249e4d952468798f78)