### PR TITLE
Improve dropdown option contrast

### DIFF
--- a/docs/css/controls.css
+++ b/docs/css/controls.css
@@ -34,6 +34,20 @@
   transition: border-color var(--motion-fast) ease, background var(--motion-fast) ease, box-shadow var(--motion-fast) ease;
 }
 
+/* Native dropdown menus inherit the OS theme, so explicitly set the palette to
+   keep options readable inside the dark UI. */
+.form-select option {
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-1);
+}
+
+.form-select option:checked,
+.form-select option:focus,
+.form-select option:hover {
+  color: var(--color-text-inverse);
+  background-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-surface-1));
+}
+
 .form-control:focus-visible,
 .form-select:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 


### PR DESCRIPTION
## Summary
- ensure native select option menus explicitly use the calculator's dark palette so entries stay visible
- add an accent-highlighted state for hovered and selected options to make the active choice easy to read

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a5524a0748324819ad5d4477b86e2)