### PR TITLE
Move runtime asserts into Vitest

### DIFF
--- a/docs/js/calculations/finishing-calculations.js
+++ b/docs/js/calculations/finishing-calculations.js
@@ -206,10 +206,3 @@ export function calculateFinishing(layout, options = {}) {
   };
 }
 
-if (typeof console !== 'undefined') {
-  const regressionPositions = generateEdgePositions(0, 1, 0, 2);
-  console.assert(
-    regressionPositions.length === 3 && new Set(regressionPositions).size === 3,
-    'Expected unique cut positions for zero gutter layouts.'
-  );
-}

--- a/docs/js/calculator-app-controller.js
+++ b/docs/js/calculator-app-controller.js
@@ -1,23 +1,7 @@
-import { DEFAULT_INPUTS } from './config/defaults.js';
 import { registerTabs } from './init/register-tabs.js';
 import { update, status } from './controllers/layout-updater.js';
-import { createCalculationContext, calculateLayout } from './calculations/layout-calculations.js';
-import { inchesToMillimeters } from './utils/units.js';
 
 registerTabs({ update, status });
-
-(function tests() {
-  console.assert(inchesToMillimeters(1) === 25.4, '1 inch should be 25.4 mm');
-  const ctx = createCalculationContext({
-    sheet: { ...DEFAULT_INPUTS.sheet },
-    document: { ...DEFAULT_INPUTS.document },
-    gutter: { ...DEFAULT_INPUTS.gutter },
-    margins: { top: 0, right: 0, bottom: 0, left: 0 },
-    nonPrintable: { ...DEFAULT_INPUTS.nonPrintable },
-  });
-  const layout = calculateLayout(ctx);
-  console.assert(layout.counts.across >= 1 && layout.counts.down >= 1, 'Counts should be >=1 with defaults');
-})();
 
 update();
 

--- a/docs/js/tabs/inputs.js
+++ b/docs/js/tabs/inputs.js
@@ -791,26 +791,6 @@ function attachKeyboardShortcut() {
   keydownHandlerAttached = true;
 }
 
-function runUnitConversionRegression() {
-  const initialUnits = currentUnitsSelection;
-  const alternateUnits = initialUnits === 'in' ? 'mm' : 'in';
-  const snapshot = numericInputSelectors
-    .map((selector) => {
-      const el = $(selector);
-      if (!el) return null;
-      return { selector, value: el.value, step: el.getAttribute('step') };
-    })
-    .filter(Boolean);
-  convertInputs(initialUnits, alternateUnits);
-  convertInputs(alternateUnits, initialUnits);
-  const mismatches = snapshot.filter(({ selector, value, step }) => {
-    const el = $(selector);
-    if (!el) return false;
-    return el.value !== value || el.getAttribute('step') !== step;
-  });
-  console.assert(mismatches.length === 0, 'Unit toggles should preserve numeric values and steps');
-}
-
 function init(context = {}) {
   hydrateTabPanel(TAB_KEY);
   storedContext = { ...storedContext, ...context };
@@ -826,7 +806,6 @@ function init(context = {}) {
   attachApplyButtons();
   attachKeyboardShortcut();
   applyDefaultInputs();
-  runUnitConversionRegression();
   initialized = true;
 }
 
@@ -854,6 +833,6 @@ export function getCurrentUnits() {
   return currentUnitsSelection;
 }
 
-export { setMeasurementInput };
+export { setMeasurementInput, convertInputs };
 
 export default inputsTab;

--- a/docs/js/utils/debug.js
+++ b/docs/js/utils/debug.js
@@ -1,0 +1,16 @@
+const root = typeof globalThis !== 'undefined' ? globalThis : window;
+
+export const DEV_ASSERTIONS_ENABLED = Boolean(root?.__DEV_ASSERTS__);
+
+export function devAssert(condition, ...args) {
+  if (!DEV_ASSERTIONS_ENABLED || typeof console === 'undefined') {
+    return;
+  }
+  if (typeof console.assert === 'function') {
+    console.assert(condition, ...args);
+    return;
+  }
+  if (!condition) {
+    console.warn('Assertion failed', ...args);
+  }
+}

--- a/tests/calculator-app-controller.test.js
+++ b/tests/calculator-app-controller.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_INPUTS } from '../docs/js/config/defaults.js';
+import { createCalculationContext, calculateLayout } from '../docs/js/calculations/layout-calculations.js';
+import { inchesToMillimeters } from '../docs/js/utils/units.js';
+
+describe('calculator bootstrap invariants', () => {
+  it('converts inches to millimeters using the canonical factor', () => {
+    expect(inchesToMillimeters(1)).toBeCloseTo(25.4, 10);
+  });
+
+  it('produces at least one document in each direction for default inputs', () => {
+    const ctx = createCalculationContext({
+      sheet: { ...DEFAULT_INPUTS.sheet },
+      document: { ...DEFAULT_INPUTS.document },
+      gutter: { ...DEFAULT_INPUTS.gutter },
+      margins: { top: 0, right: 0, bottom: 0, left: 0 },
+      nonPrintable: { ...DEFAULT_INPUTS.nonPrintable },
+    });
+    const layout = calculateLayout(ctx);
+
+    expect(layout.counts.across).toBeGreaterThanOrEqual(1);
+    expect(layout.counts.down).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/finishing-calculations.test.js
+++ b/tests/finishing-calculations.test.js
@@ -158,7 +158,7 @@ describe('finishing calculation helpers edge cases', () => {
     expect(result.perforations.vertical).toEqual([]);
   });
 
-  it('sanitizes offsets and handles zero gutters without duplicate cuts', () => {
+  it('sanitizes offsets for score generation', () => {
     const sanitized = generateScorePositions(1, 2, 0.5, 2, [
       -1,
       0,
@@ -170,7 +170,9 @@ describe('finishing calculation helpers edge cases', () => {
     ]);
 
     expect(sanitized).toEqual([1, 1, 1.4, 2.6, 3, 1, 3.5, 3.5, 3.9, 5.1, 5.5, 3.5]);
+  });
 
+  it('avoids duplicate cut positions for zero-gutter layouts', () => {
     const zeroGutterEdges = generateEdgePositions(0, 1, 0, 2);
     expect(new Set(zeroGutterEdges).size).toBe(zeroGutterEdges.length);
 

--- a/tests/inputs-unit-toggle.test.js
+++ b/tests/inputs-unit-toggle.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setMeasurementInput, convertInputs } from '../docs/js/tabs/inputs.js';
+
+class MockInput {
+  constructor(selector, options = {}) {
+    this.selector = selector;
+    this.dataset = { ...options.dataset };
+    this.value = options.value ?? '';
+    this.attributes = new Map();
+    if (options.attributes) {
+      Object.entries(options.attributes).forEach(([key, value]) => {
+        this.setAttribute(key, value);
+      });
+    }
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+}
+
+describe('inputs tab unit toggle regression', () => {
+  let elements;
+  beforeEach(() => {
+    elements = new Map();
+    global.document = {
+      querySelector: (selector) => elements.get(selector) ?? null,
+      querySelectorAll: () => [],
+    };
+  });
+
+  afterEach(() => {
+    delete global.document;
+  });
+
+  it('preserves numeric values and steps when converting units back and forth', () => {
+    const selectors = ['#docW', '#docH', '#gutH'];
+    selectors.forEach((selector) => {
+      elements.set(
+        selector,
+        new MockInput(selector, {
+          dataset: { inchStep: '0.125', inchMin: '0.25', inchMax: '24' },
+          attributes: { step: '0.125', min: '0.25', max: '24' },
+        })
+      );
+    });
+
+    setMeasurementInput('#docW', 3.5, 'in');
+    setMeasurementInput('#docH', 2, 'in');
+    setMeasurementInput('#gutH', 0.125, 'in');
+
+    const snapshot = selectors.map((selector) => {
+      const el = elements.get(selector);
+      return { selector, value: el.value, step: el.getAttribute('step') };
+    });
+
+    convertInputs('in', 'mm');
+    convertInputs('mm', 'in');
+
+    snapshot.forEach(({ selector, value, step }) => {
+      const el = elements.get(selector);
+      expect(el.value).toBe(value);
+      expect(el.getAttribute('step')).toBe(step);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- remove the browser console self-tests and expose a dev assertion helper for future debugging
- add Vitest coverage for the controller smoke tests, finishing regression, and the unit toggle round trip behaviour
- export the conversion helper so the unit toggle regression can be validated outside of production bundles

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a68e91d00832495c7b4b6b6780438)