### PR TITLE
Gracefully handle missing layout data in finishing calculations

### DIFF
--- a/docs/js/calculations/finishing-calculations.js
+++ b/docs/js/calculations/finishing-calculations.js
@@ -158,36 +158,37 @@ export const mapPositionsToReadout = (label, positions) =>
     millimeters: inchesToMillimeters(p),
   }));
 
-export function calculateFinishing(layout, options = {}) {
-  const { layoutArea, counts, document, gutter } = layout;
-  const hEdges = generateEdgePositions(layoutArea.originY, document.height, gutter.vertical, counts.down);
-  const vEdges = generateEdgePositions(layoutArea.originX, document.width, gutter.horizontal, counts.across);
-  const hScores = generateScorePositions(
-    layoutArea.originY,
-    document.height,
-    gutter.vertical,
-    counts.down,
-    options.scoreHorizontal
-  );
-  const vScores = generateScorePositions(
-    layoutArea.originX,
-    document.width,
-    gutter.horizontal,
-    counts.across,
-    options.scoreVertical
-  );
+export function calculateFinishing(layout = {}, options = {}) {
+  const layoutArea = layout?.layoutArea ?? {};
+  const counts = layout?.counts ?? {};
+  const document = layout?.document ?? {};
+  const gutter = layout?.gutter ?? {};
+
+  const originX = Number.isFinite(layoutArea.originX) ? layoutArea.originX : 0;
+  const originY = Number.isFinite(layoutArea.originY) ? layoutArea.originY : 0;
+  const docWidth = Number.isFinite(document.width) && document.width > 0 ? document.width : 0;
+  const docHeight = Number.isFinite(document.height) && document.height > 0 ? document.height : 0;
+  const horizontalGutter = Number.isFinite(gutter.horizontal) ? gutter.horizontal : 0;
+  const verticalGutter = Number.isFinite(gutter.vertical) ? gutter.vertical : 0;
+  const countAcross = Math.max(0, Number.isFinite(counts.across) ? counts.across : 0);
+  const countDown = Math.max(0, Number.isFinite(counts.down) ? counts.down : 0);
+
+  const hEdges = generateEdgePositions(originY, docHeight, verticalGutter, countDown);
+  const vEdges = generateEdgePositions(originX, docWidth, horizontalGutter, countAcross);
+  const hScores = generateScorePositions(originY, docHeight, verticalGutter, countDown, options.scoreHorizontal);
+  const vScores = generateScorePositions(originX, docWidth, horizontalGutter, countAcross, options.scoreVertical);
   const hPerforations = generateScorePositions(
-    layoutArea.originY,
-    document.height,
-    gutter.vertical,
-    counts.down,
+    originY,
+    docHeight,
+    verticalGutter,
+    countDown,
     options.perforationHorizontal
   );
   const vPerforations = generateScorePositions(
-    layoutArea.originX,
-    document.width,
-    gutter.horizontal,
-    counts.across,
+    originX,
+    docWidth,
+    horizontalGutter,
+    countAcross,
     options.perforationVertical
   );
   const holes = generateHolePositions(layout, options.holePlan);

--- a/tests/finishing-calculations.test.js
+++ b/tests/finishing-calculations.test.js
@@ -133,6 +133,71 @@ describe('hole drilling generation', () => {
   });
 });
 
+describe('calculateFinishing layout resilience', () => {
+  it('returns empty measurement collections when layout is omitted', () => {
+    const result = calculateFinishing(undefined, {
+      scoreHorizontal: [0.5],
+      scoreVertical: [0.5],
+      perforationHorizontal: [0.25],
+      perforationVertical: [0.25],
+    });
+
+    expect(result).toEqual({
+      cuts: [],
+      slits: [],
+      scores: { horizontal: [], vertical: [] },
+      perforations: { horizontal: [], vertical: [] },
+      holes: [],
+    });
+  });
+
+  it('falls back to defaults when only partial layout data is provided', () => {
+    const layout = {
+      layoutArea: { originX: 1 },
+      counts: { across: 2 },
+      document: { width: 4 },
+    };
+
+    const result = calculateFinishing(layout, {
+      scoreVertical: [0.5],
+      perforationVertical: [0.25],
+    });
+
+    expect(result.cuts).toEqual([]);
+    expect(result.scores.horizontal).toEqual([]);
+    expect(result.perforations.horizontal).toEqual([]);
+
+    const expectedSlits = [1, 5, 9];
+    expect(result.slits).toEqual(
+      expectedSlits.map((value, index) => ({
+        label: `Slit ${index + 1}`,
+        inches: Number(value.toFixed(3)),
+        millimeters: mm(value),
+      }))
+    );
+
+    const expectedVerticalScores = [3, 7];
+    expect(result.scores.vertical).toEqual(
+      expectedVerticalScores.map((value, index) => ({
+        label: `Score ${index + 1}`,
+        inches: Number(value.toFixed(3)),
+        millimeters: mm(value),
+      }))
+    );
+
+    const expectedVerticalPerforations = [2, 6];
+    expect(result.perforations.vertical).toEqual(
+      expectedVerticalPerforations.map((value, index) => ({
+        label: `Perforation ${index + 1}`,
+        inches: Number(value.toFixed(3)),
+        millimeters: mm(value),
+      }))
+    );
+
+    expect(result.holes).toEqual([]);
+  });
+});
+
 describe('finishing calculation helpers edge cases', () => {
   it('returns empty arrays for zero documents', () => {
     expect(generateEdgePositions(0, 2, 0.5, 0)).toEqual([]);


### PR DESCRIPTION
## Summary
- add defensive defaults to `calculateFinishing` so missing layout data does not cause runtime errors and results in empty readouts when necessary
- continue to support hole generation while sanitizing document and gutter measurements
- extend the finishing calculation tests to cover omitted and partial layout inputs

## Testing
- `npm test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a68e9cab48324ac69078f6aafb481)