### PR TITLE
Ensure finishing readouts share millimeter precision

### DIFF
--- a/docs/js/calculations/finishing-calculations.js
+++ b/docs/js/calculations/finishing-calculations.js
@@ -1,4 +1,8 @@
-import { clampToZero, inchesToMillimeters } from '../utils/units.js';
+import {
+  clampToZero,
+  inchesToMillimeters,
+  DISPLAY_MILLIMETERS_PRECISION,
+} from '../utils/units.js';
 
 const VALID_HOLE_EDGES = new Set(['top', 'bottom', 'left', 'right']);
 const VALID_HOLE_ALIGNS = new Set(['start', 'center', 'end']);
@@ -151,12 +155,17 @@ export function generateScorePositions(startOffset, docSpan, gutterSpan, docCoun
   return out;
 }
 
-export const mapPositionsToReadout = (label, positions) =>
-  positions.map((p, i) => ({
+export const mapPositionsToReadout = (label, positions, precision = {}) => {
+  const inchesPrecision = Number.isFinite(precision.inches) ? precision.inches : 3;
+  const millimetersPrecision = Number.isFinite(precision.millimeters)
+    ? precision.millimeters
+    : DISPLAY_MILLIMETERS_PRECISION;
+  return positions.map((p, i) => ({
     label: `${label} ${i + 1}`,
-    inches: Number(p.toFixed(3)),
-    millimeters: inchesToMillimeters(p),
+    inches: Number(p.toFixed(inchesPrecision)),
+    millimeters: inchesToMillimeters(p, millimetersPrecision),
   }));
+};
 
 export function calculateFinishing(layout, options = {}) {
   const { layoutArea, counts, document, gutter } = layout;

--- a/docs/js/tabs/print.js
+++ b/docs/js/tabs/print.js
@@ -2,7 +2,7 @@ import { hydrateTabPanel } from './registry.js';
 import { createPrintableSvg } from '../rendering/svg-print-renderer.js';
 import { createLayoutDetailsSvg } from '../rendering/svg-layout-details-renderer.js';
 import { calculateProgramSequence } from '../utils/program-sequence.js';
-import { inchesToMillimeters } from '../utils/units.js';
+import { inchesToMillimeters, DISPLAY_MILLIMETERS_PRECISION } from '../utils/units.js';
 
 const TAB_KEY = 'print';
 const DEFAULT_LAYERS = ['sheet', 'nonPrintable', 'layout', 'docs', 'cuts', 'slits', 'scores', 'perforations', 'holes'];
@@ -30,7 +30,10 @@ const state = {
   programSequence: null,
 };
 
-const fmtInches = (inches) => `${inches.toFixed(3)} in / ${inchesToMillimeters(inches).toFixed(2)} mm`;
+export const fmtInches = (inches) => {
+  const mm = inchesToMillimeters(inches, DISPLAY_MILLIMETERS_PRECISION);
+  return `${inches.toFixed(3)} in / ${mm.toFixed(DISPLAY_MILLIMETERS_PRECISION)} mm`;
+};
 
 function ensurePanel() {
   if (panelEl) return panelEl;

--- a/docs/js/utils/dom.js
+++ b/docs/js/utils/dom.js
@@ -1,4 +1,4 @@
-import { inchesToMillimeters } from './units.js';
+import { inchesToMillimeters, DISPLAY_MILLIMETERS_PRECISION } from './units.js';
 
 export const $ = (selector) => document.querySelector(selector);
 export const $$ = (selector) => Array.from(document.querySelectorAll(selector));
@@ -99,16 +99,22 @@ export const setLayerVisibility = (layer, visible) => {
 
 export const getLayerVisibility = (layer) => layerVisibility[layer] ?? true;
 
+const formatDisplayValue = (value, precision) => {
+  if (!Number.isFinite(value)) return '—';
+  return value.toFixed(precision);
+};
+
 export const fillTable = (tbody, rows, type = 'measure') => {
   if (!tbody) return;
+  const mmPrecision = DISPLAY_MILLIMETERS_PRECISION;
   tbody.innerHTML = rows
     .map((row, index) => {
       const id = createMeasurementId(type, index);
       registerMeasurementId(id);
       const cells = [
         `<td>${row.label}</td>`,
-        `<td class="k">${row.inches.toFixed(3)}</td>`,
-        `<td class="k">${row.millimeters.toFixed(2)}</td>`,
+        `<td class="k">${formatDisplayValue(row.inches, 3)}</td>`,
+        `<td class="k">${formatDisplayValue(row.millimeters, mmPrecision)}</td>`,
       ];
       return `<tr class="viz-measure-row" data-measure-id="${id}" data-measure-type="${type}" data-measure-index="${index}">${cells.join('')}</tr>`;
     })
@@ -124,6 +130,7 @@ export const fillTable = (tbody, rows, type = 'measure') => {
 export const fillHoleTable = (tbody, holes = []) => {
   if (!tbody) return;
   const rows = Array.isArray(holes) ? holes : [];
+  const mmPrecision = DISPLAY_MILLIMETERS_PRECISION;
   tbody.innerHTML = rows
     .map((hole, index) => {
       const id = createMeasurementId('hole', index);
@@ -132,14 +139,17 @@ export const fillHoleTable = (tbody, holes = []) => {
       const x = Number(hole?.x ?? 0);
       const y = Number(hole?.y ?? 0);
       const diameter = Math.max(0, Number(hole?.diameter ?? 0));
+      const mmX = inchesToMillimeters(x, mmPrecision);
+      const mmY = inchesToMillimeters(y, mmPrecision);
+      const mmDiameter = inchesToMillimeters(diameter, mmPrecision);
       const cells = [
         `<td>${label}</td>`,
-        `<td class="k">${x.toFixed(3)}</td>`,
-        `<td class="k">${y.toFixed(3)}</td>`,
-        `<td class="k">${diameter.toFixed(3)}</td>`,
-        `<td class="k">${inchesToMillimeters(x).toFixed(2)}</td>`,
-        `<td class="k">${inchesToMillimeters(y).toFixed(2)}</td>`,
-        `<td class="k">${inchesToMillimeters(diameter).toFixed(2)}</td>`,
+        `<td class="k">${formatDisplayValue(x, 3)}</td>`,
+        `<td class="k">${formatDisplayValue(y, 3)}</td>`,
+        `<td class="k">${formatDisplayValue(diameter, 3)}</td>`,
+        `<td class="k">${formatDisplayValue(mmX, mmPrecision)}</td>`,
+        `<td class="k">${formatDisplayValue(mmY, mmPrecision)}</td>`,
+        `<td class="k">${formatDisplayValue(mmDiameter, mmPrecision)}</td>`,
       ];
       return `<tr class="viz-measure-row" data-measure-id="${id}" data-measure-type="hole" data-measure-index="${index}">${cells.join('')}</tr>`;
     })

--- a/docs/js/utils/units.js
+++ b/docs/js/utils/units.js
@@ -1,4 +1,11 @@
 export const MM_PER_INCH = 25.4;
+export const DISPLAY_MILLIMETERS_PRECISION = 2;
+
+const roundToPrecision = (value, precision) => {
+  if (!Number.isFinite(value)) return 0;
+  if (!Number.isFinite(precision)) return value;
+  return Number(value.toFixed(precision));
+};
 
 export const clampToZero = (value) => Math.max(0, value);
 
@@ -16,7 +23,7 @@ export const trimTrailingZeros = (str) => {
 export const getUnitsPrecision = (units) => (units === 'mm' ? 2 : 3);
 
 export const inchesToMillimeters = (inches, precision = 3) =>
-  Number((inches * MM_PER_INCH).toFixed(precision));
+  roundToPrecision(inches * MM_PER_INCH, precision);
 
 export const formatUnitsValue = (value, units, precisionOverride) => {
   if (value == null || value === '') return '';

--- a/tests/finishing-calculations.test.js
+++ b/tests/finishing-calculations.test.js
@@ -5,8 +5,10 @@ import {
   mapPositionsToReadout,
   calculateFinishing,
 } from '../docs/js/calculations/finishing-calculations.js';
+import { fmtInches } from '../docs/js/tabs/print.js';
+import { DISPLAY_MILLIMETERS_PRECISION, MM_PER_INCH } from '../docs/js/utils/units.js';
 
-const mm = (inches) => Number((inches * 25.4).toFixed(3));
+const mm = (inches) => Number((inches * MM_PER_INCH).toFixed(DISPLAY_MILLIMETERS_PRECISION));
 
 describe('finishing calculations integration', () => {
   it('produces mapped cut, slit, score, and perforation readouts for a representative layout', () => {
@@ -130,6 +132,20 @@ describe('hole drilling generation', () => {
 
     const expectedSecondRowFirstDoc = { label: 'Hole 1 — Doc 1,2', x: 1.3125, y: 10.5, diameter: 0.25 };
     expect(result.holes[6]).toMatchObject(expectedSecondRowFirstDoc);
+  });
+});
+
+describe('display readouts share millimeter precision', () => {
+  it('matches preview rows and print summaries', () => {
+    const sample = 0.049;
+    const readout = mapPositionsToReadout('Cut', [sample])[0];
+    const printSummary = fmtInches(sample);
+    const match = printSummary.match(/\/\s+([0-9.]+)\s+mm/);
+    expect(match).not.toBeNull();
+    const [, mmText] = match;
+    expect(Number(mmText)).toBe(readout.millimeters);
+    const decimals = mmText.includes('.') ? mmText.split('.')[1].length : 0;
+    expect(decimals).toBeLessThanOrEqual(DISPLAY_MILLIMETERS_PRECISION);
   });
 });
 


### PR DESCRIPTION
## Summary
- centralize measurement rounding so preview tables consume pre-rounded inch/mm values and hole rows share the same helper
- align mapPositionsToReadout and print summaries on a shared millimeter precision constant and expose fmtInches for validation
- add regression coverage to ensure finishing readouts and printable summaries display matching millimeter values

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a68eba23c8324aaa16d3f242bfbae)