### PR TITLE
Ensure consistent millimeter rounding across finishing outputs

### DIFF
--- a/docs/js/rendering/svg-layout-details-renderer.js
+++ b/docs/js/rendering/svg-layout-details-renderer.js
@@ -1,7 +1,8 @@
-import { inchesToMillimeters } from '../utils/units.js';
+import { inchesToMillimeters, getUnitsPrecision } from '../utils/units.js';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const PRINT_DPI = 96;
+const MILLIMETER_PRECISION = getUnitsPrecision('mm');
 
 const INLINE_STYLE_MARKER = 'data-layout-details-style';
 
@@ -96,7 +97,7 @@ function formatDistanceInches(value, digits = 3) {
   return `${n.toFixed(digits)} in`;
 }
 
-function formatDistanceMillimeters(value, digits = 2) {
+function formatDistanceMillimeters(value, digits = MILLIMETER_PRECISION) {
   const n = Number(value);
   if (!Number.isFinite(n)) return '—';
   return `${n.toFixed(digits)} mm`;
@@ -105,8 +106,8 @@ function formatDistanceMillimeters(value, digits = 2) {
 function formatMeasurementPair(inches) {
   const n = Number(inches);
   if (!Number.isFinite(n)) return '—';
-  const mm = inchesToMillimeters(n);
-  return `${n.toFixed(3)} in (${mm.toFixed(2)} mm)`;
+  const mm = inchesToMillimeters(n, MILLIMETER_PRECISION);
+  return `${n.toFixed(3)} in (${mm.toFixed(MILLIMETER_PRECISION)} mm)`;
 }
 
 function formatPerSide(perSide = {}) {

--- a/docs/js/tabs/print.js
+++ b/docs/js/tabs/print.js
@@ -2,7 +2,7 @@ import { hydrateTabPanel } from './registry.js';
 import { createPrintableSvg } from '../rendering/svg-print-renderer.js';
 import { createLayoutDetailsSvg } from '../rendering/svg-layout-details-renderer.js';
 import { calculateProgramSequence } from '../utils/program-sequence.js';
-import { inchesToMillimeters } from '../utils/units.js';
+import { inchesToMillimeters, getUnitsPrecision } from '../utils/units.js';
 
 const TAB_KEY = 'print';
 const DEFAULT_LAYERS = ['sheet', 'nonPrintable', 'layout', 'docs', 'cuts', 'slits', 'scores', 'perforations', 'holes'];
@@ -30,7 +30,12 @@ const state = {
   programSequence: null,
 };
 
-const fmtInches = (inches) => `${inches.toFixed(3)} in / ${inchesToMillimeters(inches).toFixed(2)} mm`;
+const INCH_PRECISION = getUnitsPrecision('in');
+const MILLIMETER_PRECISION = getUnitsPrecision('mm');
+const fmtInches = (inches) =>
+  `${inches.toFixed(INCH_PRECISION)} in / ${inchesToMillimeters(inches, MILLIMETER_PRECISION).toFixed(
+    MILLIMETER_PRECISION,
+  )} mm`;
 
 function ensurePanel() {
   if (panelEl) return panelEl;

--- a/docs/js/utils/dom.js
+++ b/docs/js/utils/dom.js
@@ -1,4 +1,7 @@
-import { inchesToMillimeters } from './units.js';
+import { inchesToMillimeters, getUnitsPrecision } from './units.js';
+
+const INCH_PRECISION = getUnitsPrecision('in');
+const MILLIMETER_PRECISION = getUnitsPrecision('mm');
 
 export const $ = (selector) => document.querySelector(selector);
 export const $$ = (selector) => Array.from(document.querySelectorAll(selector));
@@ -107,8 +110,8 @@ export const fillTable = (tbody, rows, type = 'measure') => {
       registerMeasurementId(id);
       const cells = [
         `<td>${row.label}</td>`,
-        `<td class="k">${row.inches.toFixed(3)}</td>`,
-        `<td class="k">${row.millimeters.toFixed(2)}</td>`,
+        `<td class="k">${row.inches.toFixed(INCH_PRECISION)}</td>`,
+        `<td class="k">${row.millimeters.toFixed(MILLIMETER_PRECISION)}</td>`,
       ];
       return `<tr class="viz-measure-row" data-measure-id="${id}" data-measure-type="${type}" data-measure-index="${index}">${cells.join('')}</tr>`;
     })
@@ -134,12 +137,12 @@ export const fillHoleTable = (tbody, holes = []) => {
       const diameter = Math.max(0, Number(hole?.diameter ?? 0));
       const cells = [
         `<td>${label}</td>`,
-        `<td class="k">${x.toFixed(3)}</td>`,
-        `<td class="k">${y.toFixed(3)}</td>`,
-        `<td class="k">${diameter.toFixed(3)}</td>`,
-        `<td class="k">${inchesToMillimeters(x).toFixed(2)}</td>`,
-        `<td class="k">${inchesToMillimeters(y).toFixed(2)}</td>`,
-        `<td class="k">${inchesToMillimeters(diameter).toFixed(2)}</td>`,
+        `<td class="k">${x.toFixed(INCH_PRECISION)}</td>`,
+        `<td class="k">${y.toFixed(INCH_PRECISION)}</td>`,
+        `<td class="k">${diameter.toFixed(INCH_PRECISION)}</td>`,
+        `<td class="k">${inchesToMillimeters(x, MILLIMETER_PRECISION).toFixed(MILLIMETER_PRECISION)}</td>`,
+        `<td class="k">${inchesToMillimeters(y, MILLIMETER_PRECISION).toFixed(MILLIMETER_PRECISION)}</td>`,
+        `<td class="k">${inchesToMillimeters(diameter, MILLIMETER_PRECISION).toFixed(MILLIMETER_PRECISION)}</td>`,
       ];
       return `<tr class="viz-measure-row" data-measure-id="${id}" data-measure-type="hole" data-measure-index="${index}">${cells.join('')}</tr>`;
     })

--- a/docs/js/utils/program-sequence.js
+++ b/docs/js/utils/program-sequence.js
@@ -1,4 +1,6 @@
-import { clampToZero, inchesToMillimeters } from './units.js';
+import { clampToZero, inchesToMillimeters, getUnitsPrecision } from './units.js';
+
+const MILLIMETER_PRECISION = getUnitsPrecision('mm');
 
 // Utility: convert any value to a finite number or fall back to zero.
 // Accepts strings, numbers, or undefined. Any non-numeric value becomes 0 so
@@ -217,7 +219,7 @@ export const calculateProgramSequence = (layout = {}) => {
       return {
         label: `Step ${index + 1}`,
         inches,
-        millimeters: inchesToMillimeters(inches),
+        millimeters: inchesToMillimeters(inches, MILLIMETER_PRECISION),
       };
     });
 };

--- a/tests/finishing-calculations.test.js
+++ b/tests/finishing-calculations.test.js
@@ -6,7 +6,7 @@ import {
   calculateFinishing,
 } from '../docs/js/calculations/finishing-calculations.js';
 
-const mm = (inches) => Number((inches * 25.4).toFixed(3));
+const mm = (inches, precision = 2) => Number((inches * 25.4).toFixed(precision));
 
 describe('finishing calculations integration', () => {
   it('produces mapped cut, slit, score, and perforation readouts for a representative layout', () => {
@@ -93,7 +93,7 @@ describe('finishing calculations integration', () => {
     ];
 
     readouts.forEach(({ inches, millimeters }) => {
-      expect(millimeters).toBeCloseTo(mm(inches), 3);
+      expect(millimeters).toBe(mm(inches));
     });
   });
 });
@@ -243,7 +243,23 @@ describe('finishing calculation helpers edge cases', () => {
 
     const readout = mapPositionsToReadout('Cut', zeroGutterEdges);
     readout.forEach(({ inches, millimeters }) => {
-      expect(millimeters).toBeCloseTo(mm(inches), 3);
+      expect(millimeters).toBe(mm(inches));
     });
+  });
+});
+
+describe('mapPositionsToReadout precision controls', () => {
+  it('rounds millimeters once to keep preview and print aligned', () => {
+    const value = 0.123456;
+    const [entry] = mapPositionsToReadout('Cut', [value]);
+    expect(entry.millimeters).toBe(mm(value));
+  });
+
+  it('honors custom precision overrides', () => {
+    const value = 1 / 3;
+    const precision = { inches: 4, millimeters: 3 };
+    const [entry] = mapPositionsToReadout('Cut', [value], precision);
+    expect(entry.inches).toBe(Number(value.toFixed(precision.inches)));
+    expect(entry.millimeters).toBe(mm(value, precision.millimeters));
   });
 });


### PR DESCRIPTION
## Summary
- centralize measurement precision for finishing readouts so preview tables and printable summaries share the same millimeter values
- update DOM, program sequence, and print renderers to reuse the shared precision helpers when formatting inches and millimeters
- add regression tests covering the new precision behavior

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a8fe02f388324a53963345261e820)