### PR TITLE
Adjust layer toggle defaults

### DIFF
--- a/docs/css/visualizer.css
+++ b/docs/css/visualizer.css
@@ -126,6 +126,19 @@
   --layout-card-shadow: var(--shadow-lg);
 }
 
+.viz-layers__header {
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--viz-layer-border);
+  margin-bottom: var(--space-2);
+}
+
+.viz-layers__title {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
 .viz-toggle-list { display: grid; gap: var(--space-2); }
 
 .viz-layer-toggle {

--- a/docs/html-partials/fragments/visualizer.html
+++ b/docs/html-partials/fragments/visualizer.html
@@ -13,10 +13,13 @@
 <section class="layout-panel viz-shell layout-stack" data-gap="cozy">
   <div class="viz-layout">
     <div class="layout-card viz-stage viz-theme"><svg id="svg" width="960" height="600" viewBox="0 0 960 600" aria-label="sheet preview"></svg></div>
-    <aside class="layout-card layout-stack viz-layers print-hidden" data-gap="cozy" aria-label="Layer visibility">
+    <aside class="layout-card layout-stack viz-layers print-hidden" data-gap="cozy" aria-labelledby="vizLayerHeading">
+      <div class="viz-layers__header">
+        <p id="vizLayerHeading" class="viz-layers__title">Layer visibility</p>
+      </div>
       <div class="viz-toggle-list">
         <label class="viz-layer-toggle" data-layer="layout">
-          <input class="viz-layer-input" type="checkbox" data-layer="layout" checked />
+          <input class="viz-layer-input" type="checkbox" data-layer="layout" />
           <span class="viz-layer-label">
             <i class="viz-legend-swatch" data-layer="layout" aria-hidden="true"></i>
             <span>Layout Area</span>
@@ -37,35 +40,35 @@
           </span>
         </label>
         <label class="viz-layer-toggle" data-layer="cuts">
-          <input class="viz-layer-input" type="checkbox" data-layer="cuts" checked />
+          <input class="viz-layer-input" type="checkbox" data-layer="cuts" />
           <span class="viz-layer-label">
             <i class="viz-legend-swatch" data-layer="cuts" aria-hidden="true"></i>
             <span>Cuts</span>
           </span>
         </label>
         <label class="viz-layer-toggle" data-layer="slits">
-          <input class="viz-layer-input" type="checkbox" data-layer="slits" checked />
+          <input class="viz-layer-input" type="checkbox" data-layer="slits" />
           <span class="viz-layer-label">
             <i class="viz-legend-swatch" data-layer="slits" aria-hidden="true"></i>
             <span>Slits</span>
           </span>
         </label>
         <label class="viz-layer-toggle" data-layer="scores">
-          <input class="viz-layer-input" type="checkbox" data-layer="scores" checked />
+          <input class="viz-layer-input" type="checkbox" data-layer="scores" />
           <span class="viz-layer-label">
             <i class="viz-legend-swatch" data-layer="scores" aria-hidden="true"></i>
             <span>Scores</span>
           </span>
         </label>
         <label class="viz-layer-toggle" data-layer="perforations">
-          <input class="viz-layer-input" type="checkbox" data-layer="perforations" checked />
+          <input class="viz-layer-input" type="checkbox" data-layer="perforations" />
           <span class="viz-layer-label">
             <i class="viz-legend-swatch" data-layer="perforations" aria-hidden="true"></i>
             <span>Perforations</span>
           </span>
         </label>
         <label class="viz-layer-toggle" data-layer="holes">
-          <input class="viz-layer-input" type="checkbox" data-layer="holes" checked />
+          <input class="viz-layer-input" type="checkbox" data-layer="holes" />
           <span class="viz-layer-label">
             <i class="viz-legend-swatch" data-layer="holes" aria-hidden="true"></i>
             <span>Holes</span>

--- a/docs/js/controllers/layout-updater.js
+++ b/docs/js/controllers/layout-updater.js
@@ -13,6 +13,7 @@ import {
   parseOffsets,
   readIntOptional,
   resetMeasurementRegistry,
+  autoActivateLayerVisibility,
 } from '../utils/dom.js';
 import { updateSummaryCalculators } from './summary-calculators.js';
 import {
@@ -182,6 +183,16 @@ export function update() {
   });
   layout.roundedCorners = readRoundedCorners();
   const programSequence = calculateProgramSequence(layout);
+
+  autoActivateLayerVisibility({
+    scores:
+      (fin.scores?.horizontal?.length ?? 0) > 0 ||
+      (fin.scores?.vertical?.length ?? 0) > 0,
+    perforations:
+      (fin.perforations?.horizontal?.length ?? 0) > 0 ||
+      (fin.perforations?.vertical?.length ?? 0) > 0,
+    holes: (fin.holes?.length ?? 0) > 0,
+  });
 
   updateDocCountField('#forceAcross', layout.counts.across);
   updateDocCountField('#forceDown', layout.counts.down);

--- a/docs/js/tabs/summary.js
+++ b/docs/js/tabs/summary.js
@@ -16,7 +16,7 @@ function init() {
     input.checked = initial;
     setLayerVisibility(layer, initial);
     input.addEventListener('change', (e) => {
-      setLayerVisibility(layer, e.target.checked);
+      setLayerVisibility(layer, e.target.checked, { userInitiated: true });
     });
   });
   applyLayerVisibility();


### PR DESCRIPTION
## Summary
- add a heading to the layer toggle list and only mark documents and the non-printable region as checked by default
- track user-managed layer toggles, sync checkbox state changes, and auto-enable scores/perforations/holes when those features are present

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b610c4b6083248099d0892b01478b)